### PR TITLE
Convert JSON objects to list of python objects

### DIFF
--- a/pymesync.py
+++ b/pymesync.py
@@ -42,7 +42,7 @@ class TimeSync(object):
         try:
             # Success!
             response = requests.post(url, json=json_content)
-            return response
+            return self._json_to_python(response)
         except requests.exceptions.RequestException as e:
             # Request error
             return e
@@ -78,7 +78,7 @@ class TimeSync(object):
         try:
             # Success!
             response = requests.get(url)
-            return response
+            return self._json_to_python(response)
         except requests.exceptions.RequestException as e:
             # Request Error
             return e
@@ -129,7 +129,7 @@ class TimeSync(object):
         try:
             # Success!
             response = requests.get(url)
-            return response
+            return self._json_to_python(response)
         except requests.exceptions.RequestException as e:
             # Request Error
             return e
@@ -149,3 +149,13 @@ class TimeSync(object):
         version is being used.
         """
         return 'v1'
+
+    def _json_to_python(self, json_object):
+        """Convert json object to native python list of objects"""
+        # return json.loads(json_object)
+        python_object = json.loads(json_object)
+
+        if not isinstance(python_object, list):
+            python_object = [python_object]
+
+        return python_object

--- a/pymesync.py
+++ b/pymesync.py
@@ -152,7 +152,6 @@ class TimeSync(object):
 
     def _json_to_python(self, json_object):
         """Convert json object to native python list of objects"""
-        # return json.loads(json_object)
         python_object = json.loads(json_object)
 
         if not isinstance(python_object, list):

--- a/setup.py
+++ b/setup.py
@@ -22,5 +22,5 @@ setup(
     license='Apache Version 2.0',
     description="pymesync - python module for the OSUOSL TimeSync API",
     long_description="pymesync - Python module for interacting with the "
-                     "OSUOSL TimeSync API"
+                     + "OSUOSL TimeSync API"
 )

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,6 @@ setup(
     url='https://github.com/osuosl/pymesync',
     license='Apache Version 2.0',
     description="pymesync - python module for the OSUOSL TimeSync API",
-    long_description=
-        "pymesync - Python module for interacting with the OSUOSL TimeSync API"
+    long_description="pymesync - Python module for interacting with the "
+                     "OSUOSL TimeSync API"
 )

--- a/tests.py
+++ b/tests.py
@@ -586,41 +586,61 @@ class TestPymesync(unittest.TestCase):
 
         json_object = '[\
             {\
-                "uri": "https://code.osuosl.org/projects/ganeti-webmgr",\
-                "name": "Ganeti Web Manager"\
-            },\
-            {\
-                "slugs": ["ganeti", "gwm"],\
-                "owner": "example-user"\
-            },\
-            {\
-                "uuid": "a034806c-00db-4fe1-8de8-514575f31bfb",\
-                "revision": 4\
-            },\
-            {\
-                "created_at": "2014-07-17",\
+                "name": "Documentation",\
+                "slugs": ["docs", "doc"],\
+                "uuid": "adf036f5-3d49-4a84-bef9-0sdb46380bbf",\
+                "revision": 1,\
+                "created_at": "2014-04-17",\
                 "deleted_at": null,\
-                "updated_at": "2014-07-20"\
+                "updated_at": null\
+            },\
+            {\
+                "name": "Coding",\
+                "slugs": ["coding", "code", "prog"],\
+                "uuid": "adf036f5-3d79-4a84-bef9-062b46320bbf",\
+                "revision": 1,\
+                "created_at": "2014-04-17",\
+                "deleted_at": null,\
+                "updated_at": null\
+            },\
+            {\
+                "name": "Research",\
+                "slugs": ["research", "res"],\
+                "uuid": "adf036s5-3d49-4a84-bef9-062b46380bbf",\
+                "revision": 1,\
+                "created_at": "2014-04-17",\
+                "deleted_at": null,\
+                "updated_at": null\
             }\
         ]'
 
         python_object = [
             {
-                u'uri': u'https://code.osuosl.org/projects/ganeti-webmgr',
-                u'name': u'Ganeti Web Manager'
-            },
-            {
-                u'owner': u'example-user',
-                u'slugs': [u'ganeti', u'gwm']
-            },
-            {
-                u'uuid': u'a034806c-00db-4fe1-8de8-514575f31bfb',
-                u'revision': 4
-            },
-            {
-                u'created_at': u'2014-07-17',
+                u'uuid': u'adf036f5-3d49-4a84-bef9-0sdb46380bbf',
+                u'created_at': u'2014-04-17',
+                u'updated_at': None,
+                u'name': u'Documentation',
                 u'deleted_at': None,
-                u'updated_at': u'2014-07-20'
+                u'slugs': [u'docs', u'doc'],
+                u'revision': 1
+            },
+            {
+                u'uuid': u'adf036f5-3d79-4a84-bef9-062b46320bbf',
+                u'created_at': u'2014-04-17',
+                u'updated_at': None,
+                u'name': u'Coding',
+                u'deleted_at': None,
+                u'slugs': [u'coding', u'code', u'prog'],
+                u'revision': 1
+            },
+            {
+                u'uuid': u'adf036s5-3d49-4a84-bef9-062b46380bbf',
+                u'created_at': u'2014-04-17',
+                u'updated_at': None,
+                u'name': u'Research',
+                u'deleted_at': None,
+                u'slugs': [u'research', u'res'],
+                u'revision': 1
             }
         ]
 

--- a/tests.py
+++ b/tests.py
@@ -1,6 +1,7 @@
 import unittest
 import pymesync
 import mock
+from mock import patch
 import requests
 import json
 
@@ -9,6 +10,11 @@ class TestPymesync(unittest.TestCase):
 
     def test_send_time_valid(self):
         """Tests TimeSync.send_time with valid data"""
+        # Patch json.loads - Since we mocked the API call, we won't actually be
+        # getting a JSON object back, we don't want this mocked forever so just
+        # patch it.
+        patched_json_loader = patch('json.loads')
+        patched_json_loader.start()
         # Parameters to be sent to TimeSync
         params = {
             "duration": 12,
@@ -38,12 +44,11 @@ class TestPymesync(unittest.TestCase):
 
         # Mock requests.post so it doesn't actually post to TimeSync
         requests.post = mock.create_autospec(requests.post)
-        # Mock json.loads - Since we mocked the API call, we won't actually be
-        # getting a JSON object back
-        json.loads = mock.Mock('json.loads')
 
         # Send it
         ts.send_time(params)
+
+        patched_json_loader.stop()
 
         # Test it
         requests.post.assert_called_with('http://ts.example.com/v1/times',
@@ -91,6 +96,12 @@ class TestPymesync(unittest.TestCase):
 
     def test_get_time_for_user(self):
         """Tests TimeSync.get_times with username query parameter"""
+        # Patch json.loads - Since we mocked the API call, we won't actually be
+        # getting a JSON object back, we don't want this mocked forever so just
+        # patch it.
+        patched_json_loader = patch('json.loads')
+        patched_json_loader.start()
+
         baseurl = 'http://ts.example.com'
         # Instantiate timesync class
         ts = pymesync.TimeSync(baseurl,
@@ -100,12 +111,11 @@ class TestPymesync(unittest.TestCase):
 
         # Mock requests.get
         requests.get = mock.Mock('requests.get')
-        # Mock json.loads - Since we mocked the API call, we won't actually be
-        # getting a JSON object back
-        json.loads = mock.Mock('json.loads')
 
         # Send it
         ts.get_times(user=[ts.user])
+
+        patched_json_loader.stop()
 
         # Test that requests.get was called with baseurl and correct parameter
         requests.get.assert_called_with(
@@ -113,6 +123,12 @@ class TestPymesync(unittest.TestCase):
 
     def test_get_time_for_proj(self):
         """Tests TimeSync.get_times with project query parameter"""
+        # Patch json.loads - Since we mocked the API call, we won't actually be
+        # getting a JSON object back, we don't want this mocked forever so just
+        # patch it.
+        patched_json_loader = patch('json.loads')
+        patched_json_loader.start()
+
         baseurl = 'http://ts.example.com'
         # Instantiate timesync class
         ts = pymesync.TimeSync(baseurl,
@@ -122,12 +138,11 @@ class TestPymesync(unittest.TestCase):
 
         # Mock requests.get
         requests.get = mock.Mock('requests.get')
-        # Mock json.loads - Since we mocked the API call, we won't actually be
-        # getting a JSON object back
-        json.loads = mock.Mock('json.loads')
 
         # Send it
         ts.get_times(project=["gwm"])
+
+        patched_json_loader.stop()
 
         # Test that requests.get was called with baseurl and correct parameter
         requests.get.assert_called_with(
@@ -135,6 +150,12 @@ class TestPymesync(unittest.TestCase):
 
     def test_get_time_for_activity(self):
         """Tests TimeSync.get_times with activity query parameter"""
+        # Patch json.loads - Since we mocked the API call, we won't actually be
+        # getting a JSON object back, we don't want this mocked forever so just
+        # patch it.
+        patched_json_loader = patch('json.loads')
+        patched_json_loader.start()
+
         baseurl = 'http://ts.example.com'
         # Instantiate timesync class
         ts = pymesync.TimeSync(baseurl,
@@ -144,12 +165,11 @@ class TestPymesync(unittest.TestCase):
 
         # Mock requests.get
         requests.get = mock.Mock('requests.get')
-        # Mock json.loads - Since we mocked the API call, we won't actually be
-        # getting a JSON object back
-        json.loads = mock.Mock('json.loads')
 
         # Send it
         ts.get_times(activity=["dev"])
+
+        patched_json_loader.stop()
 
         # Test that requests.get was called with baseurl and correct parameter
         requests.get.assert_called_with(
@@ -157,6 +177,12 @@ class TestPymesync(unittest.TestCase):
 
     def test_get_time_for_start_date(self):
         """Tests TimeSync.get_times with start date query parameter"""
+        # Patch json.loads - Since we mocked the API call, we won't actually be
+        # getting a JSON object back, we don't want this mocked forever so just
+        # patch it.
+        patched_json_loader = patch('json.loads')
+        patched_json_loader.start()
+
         baseurl = 'http://ts.example.com'
         # Instantiate timesync class
         ts = pymesync.TimeSync(baseurl,
@@ -166,12 +192,11 @@ class TestPymesync(unittest.TestCase):
 
         # Mock requests.get
         requests.get = mock.Mock('requests.get')
-        # Mock json.loads - Since we mocked the API call, we won't actually be
-        # getting a JSON object back
-        json.loads = mock.Mock('json.loads')
 
         # Send it
         ts.get_times(start=["2015-07-23"])
+
+        patched_json_loader.stop()
 
         # Test that requests.get was called with baseurl and correct parameter
         requests.get.assert_called_with(
@@ -179,6 +204,12 @@ class TestPymesync(unittest.TestCase):
 
     def test_get_time_for_end_date(self):
         """Tests TimeSync.get_times with end date query parameter"""
+        # Patch json.loads - Since we mocked the API call, we won't actually be
+        # getting a JSON object back, we don't want this mocked forever so just
+        # patch it.
+        patched_json_loader = patch('json.loads')
+        patched_json_loader.start()
+
         baseurl = 'http://ts.example.com'
         # Instantiate timesync class
         ts = pymesync.TimeSync(baseurl,
@@ -188,12 +219,11 @@ class TestPymesync(unittest.TestCase):
 
         # Mock requests.get
         requests.get = mock.Mock('requests.get')
-        # Mock json.loads - Since we mocked the API call, we won't actually be
-        # getting a JSON object back
-        json.loads = mock.Mock('json.loads')
 
         # Send it
         ts.get_times(end=["2015-07-23"])
+
+        patched_json_loader.stop()
 
         # Test that requests.get was called with baseurl and correct parameter
         requests.get.assert_called_with(
@@ -201,6 +231,12 @@ class TestPymesync(unittest.TestCase):
 
     def test_get_time_for_revisions(self):
         """Tests TimeSync.get_times with revisions query parameter"""
+        # Patch json.loads - Since we mocked the API call, we won't actually be
+        # getting a JSON object back, we don't want this mocked forever so just
+        # patch it.
+        patched_json_loader = patch('json.loads')
+        patched_json_loader.start()
+
         baseurl = 'http://ts.example.com'
         # Instantiate timesync class
         ts = pymesync.TimeSync(baseurl,
@@ -210,12 +246,11 @@ class TestPymesync(unittest.TestCase):
 
         # Mock requests.get
         requests.get = mock.Mock('requests.get')
-        # Mock json.loads - Since we mocked the API call, we won't actually be
-        # getting a JSON object back
-        json.loads = mock.Mock('json.loads')
 
         # Send it
         ts.get_times(revisions=["true"])
+
+        patched_json_loader.stop()
 
         # Test that requests.get was called with baseurl and correct parameter
         requests.get.assert_called_with(
@@ -224,6 +259,12 @@ class TestPymesync(unittest.TestCase):
     def test_get_time_for_proj_and_activity(self):
         """Tests TimeSync.get_times with project and activity query
         parameters"""
+        # Patch json.loads - Since we mocked the API call, we won't actually be
+        # getting a JSON object back, we don't want this mocked forever so just
+        # patch it.
+        patched_json_loader = patch('json.loads')
+        patched_json_loader.start()
+
         baseurl = 'http://ts.example.com'
         # Instantiate timesync class
         ts = pymesync.TimeSync(baseurl,
@@ -233,12 +274,11 @@ class TestPymesync(unittest.TestCase):
 
         # Mock requests.get
         requests.get = mock.Mock('requests.get')
-        # Mock json.loads - Since we mocked the API call, we won't actually be
-        # getting a JSON object back
-        json.loads = mock.Mock('json.loads')
 
         # Send it
         ts.get_times(project=["gwm"], activity=["dev"])
+
+        patched_json_loader.stop()
 
         # Test that requests.get was called with baseurl and correct parameters
         # Multiple paramaters are sorted alphabetically
@@ -248,6 +288,12 @@ class TestPymesync(unittest.TestCase):
     def test_get_time_for_activity_x3(self):
         """Tests TimeSync.get_times with project and activity query
         parameters"""
+        # Patch json.loads - Since we mocked the API call, we won't actually be
+        # getting a JSON object back, we don't want this mocked forever so just
+        # patch it.
+        patched_json_loader = patch('json.loads')
+        patched_json_loader.start()
+
         baseurl = 'http://ts.example.com'
         # Instantiate timesync class
         ts = pymesync.TimeSync(baseurl,
@@ -257,12 +303,11 @@ class TestPymesync(unittest.TestCase):
 
         # Mock requests.get
         requests.get = mock.Mock('requests.get')
-        # Mock json.loads - Since we mocked the API call, we won't actually be
-        # getting a JSON object back
-        json.loads = mock.Mock('json.loads')
 
         # Send it
         ts.get_times(activity=["dev", "rev", "hd"])
+
+        patched_json_loader.stop()
 
         # Test that requests.get was called with baseurl and correct parameters
         # Multiple paramaters are sorted alphabetically
@@ -273,6 +318,12 @@ class TestPymesync(unittest.TestCase):
 
     def test_get_all_times(self):
         """Tests TimeSync.get_times with no paramaters"""
+        # Patch json.loads - Since we mocked the API call, we won't actually be
+        # getting a JSON object back, we don't want this mocked forever so just
+        # patch it.
+        patched_json_loader = patch('json.loads')
+        patched_json_loader.start()
+
         baseurl = 'http://ts.example.com'
         # Instantiate timesync class
         ts = pymesync.TimeSync(baseurl,
@@ -282,12 +333,11 @@ class TestPymesync(unittest.TestCase):
 
         # Mock requests.get
         requests.get = mock.Mock('requests.get')
-        # Mock json.loads - Since we mocked the API call, we won't actually be
-        # getting a JSON object back
-        json.loads = mock.Mock('json.loads')
 
         # Send it
         ts.get_times()
+
+        patched_json_loader.stop()
 
         # Test that requests.get was called with baseurl and correct parameter
         requests.get.assert_called_with('http://ts.example.com/v1/times')
@@ -307,6 +357,12 @@ class TestPymesync(unittest.TestCase):
 
     def test_get_projects(self):
         """Tests TimeSync.get_projects"""
+        # Patch json.loads - Since we mocked the API call, we won't actually be
+        # getting a JSON object back, we don't want this mocked forever so just
+        # patch it.
+        patched_json_loader = patch('json.loads')
+        patched_json_loader.start()
+
         baseurl = 'http://ts.example.com'
         # Instantiate timesync class
         ts = pymesync.TimeSync(baseurl,
@@ -316,18 +372,23 @@ class TestPymesync(unittest.TestCase):
 
         # Mock requests.get
         requests.get = mock.Mock('requests.get')
-        # Mock json.loads - Since we mocked the API call, we won't actually be
-        # getting a JSON object back
-        json.loads = mock.Mock('json.loads')
 
         # Send it
         ts.get_projects()
+
+        patched_json_loader.stop()
 
         # Test that requests.get was called correctly
         requests.get.assert_called_with('http://ts.example.com/v1/projects')
 
     def test_get_projects_slug(self):
         """Tests TimeSync.get_projects with slug"""
+        # Patch json.loads - Since we mocked the API call, we won't actually be
+        # getting a JSON object back, we don't want this mocked forever so just
+        # patch it.
+        patched_json_loader = patch('json.loads')
+        patched_json_loader.start()
+
         baseurl = 'http://ts.example.com'
         # Instantiate timesync class
         ts = pymesync.TimeSync(baseurl,
@@ -337,12 +398,11 @@ class TestPymesync(unittest.TestCase):
 
         # Mock requests.get
         requests.get = mock.Mock('requests.get')
-        # Mock json.loads - Since we mocked the API call, we won't actually be
-        # getting a JSON object back
-        json.loads = mock.Mock('json.loads')
 
         # Send it
         ts.get_projects(slug='gwm')
+
+        patched_json_loader.stop()
 
         # Test that requests.get was called correctly
         requests.get.assert_called_with(
@@ -350,6 +410,12 @@ class TestPymesync(unittest.TestCase):
 
     def test_get_projects_revisions(self):
         """Tests TimeSync.get_projects with revisions query"""
+        # Patch json.loads - Since we mocked the API call, we won't actually be
+        # getting a JSON object back, we don't want this mocked forever so just
+        # patch it.
+        patched_json_loader = patch('json.loads')
+        patched_json_loader.start()
+
         baseurl = 'http://ts.example.com'
         # Instantiate timesync class
         ts = pymesync.TimeSync(baseurl,
@@ -359,12 +425,11 @@ class TestPymesync(unittest.TestCase):
 
         # Mock requests.get
         requests.get = mock.Mock('requests.get')
-        # Mock json.loads - Since we mocked the API call, we won't actually be
-        # getting a JSON object back
-        json.loads = mock.Mock('json.loads')
 
         # Send it
         ts.get_projects(revisions=True)
+
+        patched_json_loader.stop()
 
         # Test that requests.get was called correctly
         requests.get.assert_called_with(
@@ -372,6 +437,12 @@ class TestPymesync(unittest.TestCase):
 
     def test_get_projects_slug_revisions(self):
         """Tests TimeSync.get_projects with revisions query and slug"""
+        # Patch json.loads - Since we mocked the API call, we won't actually be
+        # getting a JSON object back, we don't want this mocked forever so just
+        # patch it.
+        patched_json_loader = patch('json.loads')
+        patched_json_loader.start()
+
         baseurl = 'http://ts.example.com'
         # Instantiate timesync class
         ts = pymesync.TimeSync(baseurl,
@@ -381,12 +452,11 @@ class TestPymesync(unittest.TestCase):
 
         # Mock requests.get
         requests.get = mock.Mock('requests.get')
-        # Mock json.loads - Since we mocked the API call, we won't actually be
-        # getting a JSON object back
-        json.loads = mock.Mock('json.loads')
 
         # Send it
         ts.get_projects(slug='gwm', revisions=True)
+
+        patched_json_loader.stop()
 
         # Test that requests.get was called correctly
         requests.get.assert_called_with(
@@ -394,6 +464,12 @@ class TestPymesync(unittest.TestCase):
 
     def test_get_projects_include_deleted(self):
         """Tests TimeSync.get_projects with include_deleted query"""
+        # Patch json.loads - Since we mocked the API call, we won't actually be
+        # getting a JSON object back, we don't want this mocked forever so just
+        # patch it.
+        patched_json_loader = patch('json.loads')
+        patched_json_loader.start()
+
         baseurl = 'http://ts.example.com'
         # Instantiate timesync class
         ts = pymesync.TimeSync(baseurl,
@@ -403,12 +479,11 @@ class TestPymesync(unittest.TestCase):
 
         # Mock requests.get
         requests.get = mock.Mock('requests.get')
-        # Mock json.loads - Since we mocked the API call, we won't actually be
-        # getting a JSON object back
-        json.loads = mock.Mock('json.loads')
 
         # Send it
         ts.get_projects(include_deleted=True)
+
+        patched_json_loader.stop()
 
         # Test that requests.get was called correctly
         requests.get.assert_called_with(
@@ -426,9 +501,6 @@ class TestPymesync(unittest.TestCase):
 
         # Mock requests.get
         requests.get = mock.Mock('requests.get')
-        # Mock json.loads - Since we mocked the API call, we won't actually be
-        # getting a JSON object back
-        json.loads = mock.Mock('json.loads')
 
         # Test that error message is returned, can't combine slug and
         # include_deleted
@@ -439,6 +511,12 @@ class TestPymesync(unittest.TestCase):
     def test_get_projects_include_deleted_revisions(self):
         """Tests TimeSync.get_projects with revisions and include_deleted
         queries"""
+        # Patch json.loads - Since we mocked the API call, we won't actually be
+        # getting a JSON object back, we don't want this mocked forever so just
+        # patch it.
+        patched_json_loader = patch('json.loads')
+        patched_json_loader.start()
+
         baseurl = 'http://ts.example.com'
         # Instantiate timesync class
         ts = pymesync.TimeSync(baseurl,
@@ -448,18 +526,106 @@ class TestPymesync(unittest.TestCase):
 
         # Mock requests.get
         requests.get = mock.Mock('requests.get')
-        # Mock json.loads - Since we mocked the API call, we won't actually be
-        # getting a JSON object back
-        json.loads = mock.Mock('json.loads')
 
         # Send it
         ts.get_projects(revisions=True, include_deleted=True)
+
+        patched_json_loader.stop()
 
         # Test that requests.get was called with correct paramaters
         requests.get.assert_called_with("http://ts.example.com/v1/projects"
                                         + "?include_deleted=true"
                                         + "&revisions=true")
 
+    def test_json_to_python_single_object(self):
+        """Test that TimeSync._json_to_python converts a json object to a python
+        list of object"""
+        baseurl = 'http://ts.example.com'
+        # Instantiate timesync class
+        ts = pymesync.TimeSync(baseurl,
+                               password="password",
+                               user="example-user",
+                               auth_type="password")
+
+        json_object = '{\
+            "uri": "https://code.osuosl.org/projects/ganeti-webmgr",\
+            "name": "Ganeti Web Manager",\
+            "slugs": ["ganeti", "gwm"],\
+            "owner": "example-user",\
+            "uuid": "a034806c-00db-4fe1-8de8-514575f31bfb",\
+            "revision": 4,\
+            "created_at": "2014-07-17",\
+            "deleted_at": null,\
+            "updated_at": "2014-07-20"\
+        }'
+
+        python_object = [
+            {
+                u'uuid': u'a034806c-00db-4fe1-8de8-514575f31bfb',
+                u'updated_at': u'2014-07-20',
+                u'created_at': u'2014-07-17',
+                u'uri': u'https://code.osuosl.org/projects/ganeti-webmgr',
+                u'name': u'Ganeti Web Manager',
+                u'owner': u'example-user',
+                u'deleted_at': None,
+                u'slugs': [u'ganeti', u'gwm'],
+                u'revision': 4
+            }
+        ]
+
+        self.assertEquals(ts._json_to_python(json_object), python_object)
+
+    def test_json_to_python_list_of_object(self):
+        """Test that TimeSync._json_to_python converts a json list of objects
+        to a python list of objects"""
+        baseurl = 'http://ts.example.com'
+        # Instantiate timesync class
+        ts = pymesync.TimeSync(baseurl,
+                               password="password",
+                               user="example-user",
+                               auth_type="password")
+
+        json_object = '[\
+            {\
+                "uri": "https://code.osuosl.org/projects/ganeti-webmgr",\
+                "name": "Ganeti Web Manager"\
+            },\
+            {\
+                "slugs": ["ganeti", "gwm"],\
+                "owner": "example-user"\
+            },\
+            {\
+                "uuid": "a034806c-00db-4fe1-8de8-514575f31bfb",\
+                "revision": 4\
+            },\
+            {\
+                "created_at": "2014-07-17",\
+                "deleted_at": null,\
+                "updated_at": "2014-07-20"\
+            }\
+        ]'
+
+        python_object = [
+            {
+                u'uri': u'https://code.osuosl.org/projects/ganeti-webmgr',
+                u'name': u'Ganeti Web Manager'
+            },
+            {
+                u'owner': u'example-user',
+                u'slugs': [u'ganeti', u'gwm']
+            },
+            {
+                u'uuid': u'a034806c-00db-4fe1-8de8-514575f31bfb',
+                u'revision': 4
+            },
+            {
+                u'created_at': u'2014-07-17',
+                u'deleted_at': None,
+                u'updated_at': u'2014-07-20'
+            }
+        ]
+
+        self.assertEquals(ts._json_to_python(json_object), python_object)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests.py
+++ b/tests.py
@@ -38,6 +38,9 @@ class TestPymesync(unittest.TestCase):
 
         # Mock requests.post so it doesn't actually post to TimeSync
         requests.post = mock.create_autospec(requests.post)
+        # Mock json.loads - Since we mocked the API call, we won't actually be
+        # getting a JSON object back
+        json.loads = mock.Mock('json.loads')
 
         # Send it
         ts.send_time(params)
@@ -97,6 +100,9 @@ class TestPymesync(unittest.TestCase):
 
         # Mock requests.get
         requests.get = mock.Mock('requests.get')
+        # Mock json.loads - Since we mocked the API call, we won't actually be
+        # getting a JSON object back
+        json.loads = mock.Mock('json.loads')
 
         # Send it
         ts.get_times(user=[ts.user])
@@ -116,6 +122,9 @@ class TestPymesync(unittest.TestCase):
 
         # Mock requests.get
         requests.get = mock.Mock('requests.get')
+        # Mock json.loads - Since we mocked the API call, we won't actually be
+        # getting a JSON object back
+        json.loads = mock.Mock('json.loads')
 
         # Send it
         ts.get_times(project=["gwm"])
@@ -135,6 +144,9 @@ class TestPymesync(unittest.TestCase):
 
         # Mock requests.get
         requests.get = mock.Mock('requests.get')
+        # Mock json.loads - Since we mocked the API call, we won't actually be
+        # getting a JSON object back
+        json.loads = mock.Mock('json.loads')
 
         # Send it
         ts.get_times(activity=["dev"])
@@ -154,6 +166,9 @@ class TestPymesync(unittest.TestCase):
 
         # Mock requests.get
         requests.get = mock.Mock('requests.get')
+        # Mock json.loads - Since we mocked the API call, we won't actually be
+        # getting a JSON object back
+        json.loads = mock.Mock('json.loads')
 
         # Send it
         ts.get_times(start=["2015-07-23"])
@@ -173,6 +188,9 @@ class TestPymesync(unittest.TestCase):
 
         # Mock requests.get
         requests.get = mock.Mock('requests.get')
+        # Mock json.loads - Since we mocked the API call, we won't actually be
+        # getting a JSON object back
+        json.loads = mock.Mock('json.loads')
 
         # Send it
         ts.get_times(end=["2015-07-23"])
@@ -192,6 +210,9 @@ class TestPymesync(unittest.TestCase):
 
         # Mock requests.get
         requests.get = mock.Mock('requests.get')
+        # Mock json.loads - Since we mocked the API call, we won't actually be
+        # getting a JSON object back
+        json.loads = mock.Mock('json.loads')
 
         # Send it
         ts.get_times(revisions=["true"])
@@ -212,6 +233,9 @@ class TestPymesync(unittest.TestCase):
 
         # Mock requests.get
         requests.get = mock.Mock('requests.get')
+        # Mock json.loads - Since we mocked the API call, we won't actually be
+        # getting a JSON object back
+        json.loads = mock.Mock('json.loads')
 
         # Send it
         ts.get_times(project=["gwm"], activity=["dev"])
@@ -233,6 +257,9 @@ class TestPymesync(unittest.TestCase):
 
         # Mock requests.get
         requests.get = mock.Mock('requests.get')
+        # Mock json.loads - Since we mocked the API call, we won't actually be
+        # getting a JSON object back
+        json.loads = mock.Mock('json.loads')
 
         # Send it
         ts.get_times(activity=["dev", "rev", "hd"])
@@ -255,6 +282,9 @@ class TestPymesync(unittest.TestCase):
 
         # Mock requests.get
         requests.get = mock.Mock('requests.get')
+        # Mock json.loads - Since we mocked the API call, we won't actually be
+        # getting a JSON object back
+        json.loads = mock.Mock('json.loads')
 
         # Send it
         ts.get_times()
@@ -286,6 +316,9 @@ class TestPymesync(unittest.TestCase):
 
         # Mock requests.get
         requests.get = mock.Mock('requests.get')
+        # Mock json.loads - Since we mocked the API call, we won't actually be
+        # getting a JSON object back
+        json.loads = mock.Mock('json.loads')
 
         # Send it
         ts.get_projects()
@@ -304,6 +337,9 @@ class TestPymesync(unittest.TestCase):
 
         # Mock requests.get
         requests.get = mock.Mock('requests.get')
+        # Mock json.loads - Since we mocked the API call, we won't actually be
+        # getting a JSON object back
+        json.loads = mock.Mock('json.loads')
 
         # Send it
         ts.get_projects(slug='gwm')
@@ -323,6 +359,9 @@ class TestPymesync(unittest.TestCase):
 
         # Mock requests.get
         requests.get = mock.Mock('requests.get')
+        # Mock json.loads - Since we mocked the API call, we won't actually be
+        # getting a JSON object back
+        json.loads = mock.Mock('json.loads')
 
         # Send it
         ts.get_projects(revisions=True)
@@ -342,6 +381,9 @@ class TestPymesync(unittest.TestCase):
 
         # Mock requests.get
         requests.get = mock.Mock('requests.get')
+        # Mock json.loads - Since we mocked the API call, we won't actually be
+        # getting a JSON object back
+        json.loads = mock.Mock('json.loads')
 
         # Send it
         ts.get_projects(slug='gwm', revisions=True)
@@ -361,6 +403,9 @@ class TestPymesync(unittest.TestCase):
 
         # Mock requests.get
         requests.get = mock.Mock('requests.get')
+        # Mock json.loads - Since we mocked the API call, we won't actually be
+        # getting a JSON object back
+        json.loads = mock.Mock('json.loads')
 
         # Send it
         ts.get_projects(include_deleted=True)
@@ -381,6 +426,9 @@ class TestPymesync(unittest.TestCase):
 
         # Mock requests.get
         requests.get = mock.Mock('requests.get')
+        # Mock json.loads - Since we mocked the API call, we won't actually be
+        # getting a JSON object back
+        json.loads = mock.Mock('json.loads')
 
         # Test that error message is returned, can't combine slug and
         # include_deleted
@@ -400,6 +448,9 @@ class TestPymesync(unittest.TestCase):
 
         # Mock requests.get
         requests.get = mock.Mock('requests.get')
+        # Mock json.loads - Since we mocked the API call, we won't actually be
+        # getting a JSON object back
+        json.loads = mock.Mock('json.loads')
 
         # Send it
         ts.get_projects(revisions=True, include_deleted=True)

--- a/tests.py
+++ b/tests.py
@@ -1,7 +1,6 @@
 import unittest
 import pymesync
 import mock
-from mock import patch
 import requests
 import json
 
@@ -13,7 +12,7 @@ class TestPymesync(unittest.TestCase):
         # Patch json.loads - Since we mocked the API call, we won't actually be
         # getting a JSON object back, we don't want this mocked forever so just
         # patch it.
-        patched_json_loader = patch('json.loads')
+        patched_json_loader = mock.patch('json.loads')
         patched_json_loader.start()
         # Parameters to be sent to TimeSync
         params = {
@@ -99,7 +98,7 @@ class TestPymesync(unittest.TestCase):
         # Patch json.loads - Since we mocked the API call, we won't actually be
         # getting a JSON object back, we don't want this mocked forever so just
         # patch it.
-        patched_json_loader = patch('json.loads')
+        patched_json_loader = mock.patch('json.loads')
         patched_json_loader.start()
 
         baseurl = 'http://ts.example.com'
@@ -126,7 +125,7 @@ class TestPymesync(unittest.TestCase):
         # Patch json.loads - Since we mocked the API call, we won't actually be
         # getting a JSON object back, we don't want this mocked forever so just
         # patch it.
-        patched_json_loader = patch('json.loads')
+        patched_json_loader = mock.patch('json.loads')
         patched_json_loader.start()
 
         baseurl = 'http://ts.example.com'
@@ -153,7 +152,7 @@ class TestPymesync(unittest.TestCase):
         # Patch json.loads - Since we mocked the API call, we won't actually be
         # getting a JSON object back, we don't want this mocked forever so just
         # patch it.
-        patched_json_loader = patch('json.loads')
+        patched_json_loader = mock.patch('json.loads')
         patched_json_loader.start()
 
         baseurl = 'http://ts.example.com'
@@ -180,7 +179,7 @@ class TestPymesync(unittest.TestCase):
         # Patch json.loads - Since we mocked the API call, we won't actually be
         # getting a JSON object back, we don't want this mocked forever so just
         # patch it.
-        patched_json_loader = patch('json.loads')
+        patched_json_loader = mock.patch('json.loads')
         patched_json_loader.start()
 
         baseurl = 'http://ts.example.com'
@@ -207,7 +206,7 @@ class TestPymesync(unittest.TestCase):
         # Patch json.loads - Since we mocked the API call, we won't actually be
         # getting a JSON object back, we don't want this mocked forever so just
         # patch it.
-        patched_json_loader = patch('json.loads')
+        patched_json_loader = mock.patch('json.loads')
         patched_json_loader.start()
 
         baseurl = 'http://ts.example.com'
@@ -234,7 +233,7 @@ class TestPymesync(unittest.TestCase):
         # Patch json.loads - Since we mocked the API call, we won't actually be
         # getting a JSON object back, we don't want this mocked forever so just
         # patch it.
-        patched_json_loader = patch('json.loads')
+        patched_json_loader = mock.patch('json.loads')
         patched_json_loader.start()
 
         baseurl = 'http://ts.example.com'
@@ -262,7 +261,7 @@ class TestPymesync(unittest.TestCase):
         # Patch json.loads - Since we mocked the API call, we won't actually be
         # getting a JSON object back, we don't want this mocked forever so just
         # patch it.
-        patched_json_loader = patch('json.loads')
+        patched_json_loader = mock.patch('json.loads')
         patched_json_loader.start()
 
         baseurl = 'http://ts.example.com'
@@ -291,7 +290,7 @@ class TestPymesync(unittest.TestCase):
         # Patch json.loads - Since we mocked the API call, we won't actually be
         # getting a JSON object back, we don't want this mocked forever so just
         # patch it.
-        patched_json_loader = patch('json.loads')
+        patched_json_loader = mock.patch('json.loads')
         patched_json_loader.start()
 
         baseurl = 'http://ts.example.com'
@@ -321,7 +320,7 @@ class TestPymesync(unittest.TestCase):
         # Patch json.loads - Since we mocked the API call, we won't actually be
         # getting a JSON object back, we don't want this mocked forever so just
         # patch it.
-        patched_json_loader = patch('json.loads')
+        patched_json_loader = mock.patch('json.loads')
         patched_json_loader.start()
 
         baseurl = 'http://ts.example.com'
@@ -360,7 +359,7 @@ class TestPymesync(unittest.TestCase):
         # Patch json.loads - Since we mocked the API call, we won't actually be
         # getting a JSON object back, we don't want this mocked forever so just
         # patch it.
-        patched_json_loader = patch('json.loads')
+        patched_json_loader = mock.patch('json.loads')
         patched_json_loader.start()
 
         baseurl = 'http://ts.example.com'
@@ -386,7 +385,7 @@ class TestPymesync(unittest.TestCase):
         # Patch json.loads - Since we mocked the API call, we won't actually be
         # getting a JSON object back, we don't want this mocked forever so just
         # patch it.
-        patched_json_loader = patch('json.loads')
+        patched_json_loader = mock.patch('json.loads')
         patched_json_loader.start()
 
         baseurl = 'http://ts.example.com'
@@ -413,7 +412,7 @@ class TestPymesync(unittest.TestCase):
         # Patch json.loads - Since we mocked the API call, we won't actually be
         # getting a JSON object back, we don't want this mocked forever so just
         # patch it.
-        patched_json_loader = patch('json.loads')
+        patched_json_loader = mock.patch('json.loads')
         patched_json_loader.start()
 
         baseurl = 'http://ts.example.com'
@@ -440,7 +439,7 @@ class TestPymesync(unittest.TestCase):
         # Patch json.loads - Since we mocked the API call, we won't actually be
         # getting a JSON object back, we don't want this mocked forever so just
         # patch it.
-        patched_json_loader = patch('json.loads')
+        patched_json_loader = mock.patch('json.loads')
         patched_json_loader.start()
 
         baseurl = 'http://ts.example.com'
@@ -467,7 +466,7 @@ class TestPymesync(unittest.TestCase):
         # Patch json.loads - Since we mocked the API call, we won't actually be
         # getting a JSON object back, we don't want this mocked forever so just
         # patch it.
-        patched_json_loader = patch('json.loads')
+        patched_json_loader = mock.patch('json.loads')
         patched_json_loader.start()
 
         baseurl = 'http://ts.example.com'
@@ -514,7 +513,7 @@ class TestPymesync(unittest.TestCase):
         # Patch json.loads - Since we mocked the API call, we won't actually be
         # getting a JSON object back, we don't want this mocked forever so just
         # patch it.
-        patched_json_loader = patch('json.loads')
+        patched_json_loader = mock.patch('json.loads')
         patched_json_loader.start()
 
         baseurl = 'http://ts.example.com'


### PR DESCRIPTION
#17 

Since [TimeSync](https://github.com/osuosl/timesync/blob/develop/source/draft_api.rst) returns either a single JSON object or a list of several JSON objects, we should convert these objects to a list of native python objects, even if there is just one JSON object in the return. That way, a user always knows how to process the returned python list.