### PR TITLE
Fix JSON encoding issues and date -> string

### DIFF
--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -158,13 +158,13 @@ Example usage:
     ...             "activities": ["documenting"],
     ...             "notes": "Worked on docs",
     ...             "issue_uri": "https://github.com/",
-    ...             "date_worked": 2014-04-17,
+    ...             "date_worked": "2014-04-17",
     ...         }
     >>> ts.send_times(params)
-    {u'object': {u'activities': [u'documenting'], u'date_worked': 1993, u'notes': u'Worked on docs', u'project': u'ganeti-web-manager', u'user': u'example-user', u'duration': 12, u'issue_uri': u'https://github.com/', u'id': 1}, u'auth': {u'username': u'example-user', u'password': u'password', u'type': u'password'}}
+    {u'object': {u'activities': [u'documenting'], u'date_worked': u'2014-04-17', u'notes': u'Worked on docs', u'project': u'ganeti-web-manager', u'user': u'example-user', u'duration': 12, u'issue_uri': u'https://github.com/', u'id': 1}, u'auth': {u'username': u'example-user', u'password': u'password', u'type': u'password'}}
     >>>
     >>> ts.get_times(user=["username"])
-    {u'object': {u'activities': [u'documenting'], u'date_worked': 1993, u'notes': u'Worked on docs', u'project': u'ganeti-web-manager', u'user': u'example-user', u'duration': 12, u'issue_uri': u'https://github.com/', u'id': 1}, u'auth': {u'username': u'example-user', u'password': u'password', u'type': u'password'}}
+    [{u'object': {u'activities': [u'documenting'], u'date_worked': u'2014-04-17', u'notes': u'Worked on docs', u'project': u'ganeti-web-manager', u'user': u'example-user', u'duration': 12, u'issue_uri': u'https://github.com/', u'id': 1}, u'auth': {u'username': u'example-user', u'password': u'password', u'type': u'password'}}]
     >>>
     >>> ts.get_projects(slug='gwm')
-    {u'owner': u'example-user', u'slugs': [u'ganeti', u'gwm'], u'id': 1, u'uri': u'https://code.osuosl.org/projects/ganeti-webmgr', u'name': u'Ganeti Web Manager'}
+    [{u'owner': u'example-user', u'slugs': [u'ganeti', u'gwm'], u'id': 1, u'uri': u'https://code.osuosl.org/projects/ganeti-webmgr', u'name': u'Ganeti Web Manager'}]

--- a/pymesync.py
+++ b/pymesync.py
@@ -43,17 +43,14 @@ class TimeSync(object):
             'object': parameter_dict,
         }
 
-        # Convert parameter_dict to JSON object
-        json_content = json.dumps(values)
-
         # Construct url to post to
         url = "{}/times".format(self.baseurl)
 
         # Attempt to POST to TimeSync
         try:
             # Success!
-            response = requests.post(url, json=json_content)
-            return self._json_to_python(response)
+            response = requests.post(url, json=values)
+            return self._json_to_python(response.text)
         except requests.exceptions.RequestException as e:
             # Request error
             return e
@@ -98,7 +95,7 @@ class TimeSync(object):
         try:
             # Success!
             response = requests.get(url)
-            return self._json_to_python(response)
+            return self._json_to_python(response.text)
         except requests.exceptions.RequestException as e:
             # Request Error
             return e
@@ -155,7 +152,7 @@ class TimeSync(object):
         try:
             # Success!
             response = requests.get(url)
-            return self._json_to_python(response)
+            return self._json_to_python(response.text)
         except requests.exceptions.RequestException as e:
             # Request Error
             return e
@@ -168,7 +165,7 @@ class TimeSync(object):
 
     def _json_to_python(self, json_object):
         """Convert json object to native python list of objects"""
-        python_object = json.loads(json_object)
+        python_object = json.loads(str(json_object))
 
         if not isinstance(python_object, list):
             python_object = [python_object]

--- a/tests.py
+++ b/tests.py
@@ -2,7 +2,6 @@ import unittest
 import pymesync
 import mock
 import requests
-import json
 
 
 class TestPymesync(unittest.TestCase):
@@ -22,7 +21,7 @@ class TestPymesync(unittest.TestCase):
             "activities": ["documenting"],
             "notes": "Worked on docs",
             "issue_uri": "https://github.com/",
-            "date_worked": 2014-04-17,
+            "date_worked": "2014-04-17",
         }
 
         # Test baseurl
@@ -38,8 +37,6 @@ class TestPymesync(unittest.TestCase):
             'auth': ts._auth(),
             'object': params,
         }
-        # Convert to json for test
-        json_content = json.dumps(content)
 
         # Mock requests.post so it doesn't actually post to TimeSync
         requests.post = mock.create_autospec(requests.post)
@@ -51,7 +48,7 @@ class TestPymesync(unittest.TestCase):
 
         # Test it
         requests.post.assert_called_with('http://ts.example.com/v1/times',
-                                         json=json_content)
+                                         json=content)
 
     def test_send_time_catch_request_error(self):
         """Tests TimeSync.send_time with request error"""
@@ -63,7 +60,7 @@ class TestPymesync(unittest.TestCase):
             "activities": ["documenting"],
             "notes": "Worked on docs",
             "issue_uri": "https://github.com/",
-            "date_worked": 2014-04-17,
+            "date_worked": "2014-04-17",
         }
 
         # Test baseurl


### PR DESCRIPTION
Fixed issues with double-encoding of JSON and made the date a string in tests and docs.

It actually works (minus the fact that I don't have permissions to post a time)!

```
>>> import pymesync
>>> ts = pymesync.TimeSync("http://<the-baseurl>/v1", password="not-the-real-one", user="mrsj", auth_type="password")
>>> params = {
...             "duration": 240,
...             "project": "pymesync",
...             "user": "mrsj",
...             "activities": ["code"],
...             "notes": "Worked on pymesync",
...             "issue_uri": "https://github.com/",
...             "date_worked": "2014-11-25",
...         }
>>> resp = ts.send_time(params)
>>> resp
[{u'status': 401, u'text': u'mrsj is not authorized to create time entries for project pymesync.', u'error': u'Authorization failure'}]
>>> resp = ts.get_times()
>>> resp
[]
>>> resp = ts.get_projects()
>>> resp
[{u'name': u'pymesync', u'created_at': u'2015-11-24', u'uri': u'https://github.com/osuosl/pymesync', u'updated_at': None, u'slugs': [u'pymesync', u'ps', u'pyme'], u'owner': u'mrsj', u'deleted_at': None, u'revision': 1, u'id': 1, u'uuid': u'35312c0c-60a4-434c-b8b2-ac4826b9a4ca'}]

```