### PR TITLE
Refactor Queries to be Python Dicts

### DIFF
--- a/docs/source/testing.rst
+++ b/docs/source/testing.rst
@@ -143,7 +143,7 @@ An (almost) exhaustive example of test mode:
   >>> ts.get_users()
   [{'username': 'userone', 'displayname': 'One Is The Loneliest Number', 'admin': False, 'created_at': '2015-02-29', 'active': True, 'deleted_at': None, 'email': 'exampleone@example.com'}, {'username': 'usertwo', 'displayname': 'Two Can Be As Bad As One', 'admin': False, 'created_at': '2015-02-29', 'active': True, 'deleted_at': None, 'email': 'exampletwo@example.com'}, {'username': 'userthree', 'displayname': "Yes It's The Saddest Experience", 'admin': False, 'created_at': '2015-02-29', 'active': True, 'deleted_at': None, 'email': 'examplethree@example.com'}, {'username': 'userfour', 'displayname': "You'll Ever Do", 'admin': False, 'created_at': '2015-02-29', 'active': True, 'deleted_at': None, 'email': 'examplefour@example.com'}]
   >>>
-  >>> ts.get_times(uuid="some-uuid")
+  >>> ts.get_times({"uuid": "some-uuid"})
   [{'activities': ['docs', 'planning'], 'date_worked': '2014-04-17', 'updated_at': None, 'user': 'userone', 'duration': 12, 'deleted_at': None, 'uuid': 'some-uuid', 'notes': 'Worked on documentation.', 'project': ['ganeti-webmgr', 'gwm'], 'issue_uri': 'https://github.com/osuosl/ganeti_webmgr', 'created_at': '2014-04-17', 'revision': 1}]
   >>>
   >>> ts.delete_time(uuid="some-uuid")

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -49,7 +49,7 @@ empty list if TimeSync has no records).
 
 |
 
-* **get_times(\**kwargs)** - Get times from TimeSync
+* **get_times(query_parameters)** - Get times from TimeSync
 * **get_projects(\**kwargs)** - Get project information from TimeSync
 * **get_activities(\**kwargs)** - Get activity information from TimeSync
 * **get_users(username=None)** - Get user information from TimeSync
@@ -315,56 +315,58 @@ TimeSync.\ **update_time(time, uuid)**
 
 ------------------------------------------
 
-TimeSync.\ **get_times(\**kwargs)**
+TimeSync.\ **get_times(query_parameters)**
 
     Request time entries from the TimeSync instance specified by the baseurl
     provided when instantiating the TimeSync object. The time entries are
-    filtered by parameters passed to ``kwargs``. Returns a list of python
-    dictionaries containing the time information returned by TimeSync or an
-    error message if unsuccessful.
+    filtered by parameters passed in ``query_parameters``. Returns a list of
+    python dictionaries containing the time information returned by TimeSync or
+    an error message if unsuccessful.
 
-    ``kwargs`` contains the optional query parameters described in the
-    `TimeSync documentation`_. If ``kwargs`` is empty, ``get_times()`` will
-    return all times in the database. The syntax for each argument is
-    ``query=["parameter1", "parameter2"]`` except for the ``uuid`` parameter
-    which is ``uuid="uuid-as-string"`` and the ``include_deleted`` and
-    ``include_revisions`` parameters which should be set to booleans.
+    ``query_parameters`` is a python dictionary containing the optional query
+    parameters described in the `TimeSync documentation`_. If 
+    ``query_parameters`` is missing, it defaults to ``None``, in which case
+    ``get_times()`` will return all times the current user is authorized to see.
+    The syntax for each argument is ``{"query": ["parameter1", "parameter2"]}``
+    except for the ``uuid`` parameter which is ``{"uuid": "uuid-as-string"}``
+    and the ``include_deleted`` and ``include_revisions`` parameters which
+    should be set to booleans.
 
     Currently the valid queries allowed by pymesync are:
 
     * ``user`` - filter time request by username
 
-      - example: ``user=["username"]``
+      - example: ``{"user": ["username"]}``
 
     * ``project`` - filter time request by project slug
 
-      - example: ``project=["slug"]``
+      - example: ``{"project": ["slug"]}``
 
     * ``activity`` - filter time request by activity slug
 
-      - example: ``activity=["slug"]``
+      - example: ``{"activity": ["slug"]}``
 
     * ``start`` - filter time request by start date
 
-      - example: ``start=["2014-07-23"]``
+      - example: ``{"start": ["2014-07-23"]}``
 
     * ``end`` - filter time request by end date
 
-      - example: ``end=["2015-07-23"]``
+      - example: ``{"end": ["2015-07-23"]}``
 
     * ``include_revisions`` - either ``True`` or ``False`` to include
       revisions of times. Defaults to ``False``
 
-      - example: ``include_revisions=True``
+      - example: ``{"include_revisions": True}``
 
     * ``include_deleted`` - either ``True`` or ``False`` to include
       deleted times. Defaults to ``False``
 
-      - example: ``include_deleted=True``
+      - example: ``{"include_deleted": True}``
 
     * ``uuid`` - get specific time entry by time uuid
 
-      - example: ``uuid="someuuid"``
+      - example: ``{"uuid": "someuuid"}``
 
       To get a deleted time by ``uuid``, also add the ``include_deleted``
       parameter.

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -50,8 +50,8 @@ empty list if TimeSync has no records).
 |
 
 * **get_times(query_parameters)** - Get times from TimeSync
-* **get_projects(\**kwargs)** - Get project information from TimeSync
-* **get_activities(\**kwargs)** - Get activity information from TimeSync
+* **get_projects(query_parameters)** - Get project information from TimeSync
+* **get_activities(query_parameters)** - Get activity information from TimeSync
 * **get_users(username=None)** - Get user information from TimeSync
 
 |
@@ -315,7 +315,7 @@ TimeSync.\ **update_time(time, uuid)**
 
 ------------------------------------------
 
-TimeSync.\ **get_times(query_parameters)**
+TimeSync.\ **get_times(query_parameters=None)**
 
     Request time entries from the TimeSync instance specified by the baseurl
     provided when instantiating the TimeSync object. The time entries are
@@ -408,34 +408,35 @@ TimeSync.\ **delete_time(uuid)**
 
 ------------------------------------------
 
-TimeSync.\ **get_projects(\**kwargs)**
+TimeSync.\ **get_projects(query_parameters=None)**
 
     Request project entries from the TimeSync instance specified by the baseurl
     provided when instantiating the TimeSync object. The project entries are
-    filtered by parameters passed to ``kwargs``. Returns a list of python
-    dictionaries containing the project information returned by TimeSync or an
-    error message if unsuccessful.
+    filtered by parameters passed in ``query_parameters``. Returns a list of
+    python dictionaries containing the project information returned by TimeSync
+    or an error message if unsuccessful.
 
-    ``kwargs`` contains the optional query parameters described in the
-    `TimeSync documentation`_. If ``kwargs`` is empty, ``get_projects()`` will
-    return all projects in the database. The syntax for each argument is
-    ``query="parameter"`` or ``bool_query=<boolean>``.
+    ``query_parameters`` is a dict containing the optional query parameters
+    described in the `TimeSync documentation`_. If ``query_parameters`` is
+    empty, ``get_projects()`` will return all projects in the database. The
+    syntax for each argument is ``{"query": "parameter"}`` or
+    ``{"bool_query": <boolean>}``.
 
     The optional parameters currently supported by the TimeSync API are:
 
     * ``slug`` - filter project request by project slug
 
-      - example: ``slug='gwm'``
+      - example: ``{"slug": "gwm"}``
 
     * ``include_deleted`` - tell TimeSync whether to include deleted projects in
       request. Default is ``False`` and cannot be combined with a ``slug``.
 
-      - example: ``include_deleted=True``
+      - example: ``{"include_deleted": True}``
 
     * ``include_revisions`` - tell TimeSync whether to include past revisions of
       projects in request. Default is ``False``
 
-      - example: ``include_revisions=True``
+      - example: ``{"include_revisions": True}``
 
     Example usage:
 
@@ -452,34 +453,35 @@ TimeSync.\ **get_projects(\**kwargs)**
 
 ------------------------------------------
 
-TimeSync.\ **get_activities(\**kwargs)**
+TimeSync.\ **get_activities(query_parameters=None)**
 
     Request activity entries from the TimeSync instance specified by the baseurl
     provided when instantiating the TimeSync object. The activity entries are
-    filtered by parameters passed to ``kwargs``. Returns a list of python
-    dictionaries containing the activity information returned by TimeSync or an
-    error message if unsuccessful.
+    filtered by parameters passed in ``query_parameters``. Returns a list of
+    python dictionaries containing the activity information returned by TimeSync
+    or an error message if unsuccessful.
 
-    ``kwargs`` contains the optional query parameters described in the
-    `TimeSync documentation`_. If ``kwargs`` is empty, ``get_activities()`` will
-    return all activities in the database. The syntax for each argument is
-    ``query="parameter"`` or ``bool_query=<boolean>``.
+    ``query_parameters`` contains the optional query parameters described in the
+    `TimeSync documentation`_. If ``query_parameters`` is empty,
+    ``get_activities()`` will return all activities in the database. The syntax
+    for each argument is ``{"query": "parameter"}`` or
+    ``{"bool_query": <boolean>}``.
 
     The optional parameters currently supported by the TimeSync API are:
 
     * ``slug`` - filter activity request by activity slug
 
-      - example: ``slug='code'``
+      - example: ``{"slug": "code"}``
 
     * ``include_deleted`` - tell TimeSync whether to include deleted activities
       in request. Default is ``False`` and cannot be combined with a ``slug``.
 
-      - example: ``include_deleted=True``
+      - example: ``{"include_deleted": True}``
 
     * ``include_revisions`` - tell TimeSync whether to include past revisions of
       activities in request. Default is ``False``
 
-      - example: ``include_revisions=True``
+      - example: ``{"include_revisions": True}``
 
     Example usage:
 

--- a/pymesync.py
+++ b/pymesync.py
@@ -271,7 +271,7 @@ class TimeSync(object):
         """
         return self.__create_or_update(user, username, "user", "users", False)
 
-    def get_times(self, **kwargs):
+    def get_times(self, query_parameters=None):
         """
         get_times([kwargs])
 
@@ -290,17 +290,18 @@ class TimeSync(object):
             return [{self.error: local_auth_error}]
 
         # Check for key error
-        for key in kwargs.keys():
-            if key not in self.valid_get_queries:
-                return [{self.error: "invalid query: {}".format(key)}]
+        if query_parameters:
+            for key in query_parameters:
+                if key not in self.valid_get_queries:
+                    return [{self.error: "invalid query: {}".format(key)}]
 
         # Initialize the query string
         query_string = ""
 
         # If there are filtering parameters, construct them correctly.
         # Else reinitialize the query string to a ? so we can add the token.
-        if kwargs:
-            query_string = self.__construct_filter_query(kwargs)
+        if query_parameters:
+            query_string = self.__construct_filter_query(query_parameters)
         else:
             query_string = "?"
 
@@ -311,8 +312,8 @@ class TimeSync(object):
 
         # Test mode, return one or many objects depending on if uuid is passed
         if self.test:
-            if "uuid" in kwargs.keys():
-                return mock_pymesync.get_times(kwargs["uuid"])
+            if query_parameters and "uuid" in query_parameters:
+                return mock_pymesync.get_times(query_parameters["uuid"])
             else:
                 return mock_pymesync.get_times(None)
 

--- a/pymesync.py
+++ b/pymesync.py
@@ -275,7 +275,7 @@ class TimeSync(object):
         """
         get_times(query_parameters)
 
-        Request time entries filtered by parameters passed in 
+        Request time entries filtered by parameters passed in
         ``query_parameters``. Returns a list of python objects representing the
         JSON time information returned by TimeSync or an error message if
         unsuccessful.

--- a/pymesync.py
+++ b/pymesync.py
@@ -345,9 +345,9 @@ class TimeSync(object):
         ``{"query": "parameter"}`` or ``{"bool_query": <boolean>}``.
 
         Optional parameters:
-        slug="<slug>"
-        include_deleted=<boolean>
-        revisions=<boolean>
+        "slug": "<slug>"
+        "include_deleted": <boolean>
+        "revisions": <boolean>
 
         Does not accept a slug combined with include_deleted, but does accept
         any other combination.
@@ -397,24 +397,25 @@ class TimeSync(object):
             # Request Error
             return [{self.error: e}]
 
-    def get_activities(self, **kwargs):
+    def get_activities(self, query_parameters=None):
         """
-        get_activities([kwargs])
+        get_activities(query_parameters)
 
         Request activity information filtered by parameters passed to
-        ``kwargs``. Returns a list of python objects representing the JSON
-        activity information returned by TimeSync or an error message if
-        unsuccessful.
+        ``query_parameters``. Returns a list of python objects representing
+        the JSON activity information returned by TimeSync or an error message
+        if unsuccessful.
 
-        ``kwargs`` contains the optional query parameters described in the
-        TimeSync documentation. If ``kwargs`` is empty, ``get_activities()``
-        will return all activities in the database. The syntax for each
-        argument is ``query="parameter"`` or ``bool_query=<boolean>``.
+        ``query_parameters`` is a dictionary containing the optional query
+        parameters described in the TimeSync documentation. If
+        ``query_parameters`` is empty or None, ``get_activities()`` will
+        return all activities in the database. The syntax for each argument is
+        ``{"query": "parameter"}`` or ``{"bool_query": <boolean>}``.
 
         Optional parameters:
-        slug="<slug>"
-        include_deleted=<boolean>
-        revisions=<boolean>
+        "slug": "<slug>"
+        "include_deleted": <boolean>
+        "revisions": <boolean>
 
         Does not accept a slug combined with include_deleted, but does accept
         any other combination.
@@ -426,14 +427,17 @@ class TimeSync(object):
 
         # Save for passing to test mode since __format_endpoints deletes
         # kwargs["slug"] if it exists
-        slug = kwargs["slug"] if "slug" in kwargs.keys() else None
+        if query_parameters and "slug" in query_parameters:
+            slug = query_parameters["slug"]
+        else:
+            slug = None
 
         query_string = ""
 
         # If kwargs exist, create a correct query string
         # Else, prepare query_string for the token
-        if kwargs:
-            query_string = self.__format_endpoints(kwargs)
+        if query_parameters:
+            query_string = self.__format_endpoints(query_parameters)
             # If __format_endpoints returns None, it was passed both slug and
             # include_deleted, which is not allowed by the TimeSync API
             if query_string is None:

--- a/test_mock_pymesync.py
+++ b/test_mock_pymesync.py
@@ -353,7 +353,8 @@ class TestMockPymesync(unittest.TestCase):
             }
         }]
 
-        self.assertEquals(self.ts.get_projects(slug="ganeti"), expected_result)
+        self.assertEquals(self.ts.get_projects({"slug": "ganeti"}),
+                          expected_result)
 
     def test_mock_get_projects_no_slug(self):
         expected_result = [
@@ -444,7 +445,7 @@ class TestMockPymesync(unittest.TestCase):
             "updated_at": None
         }]
 
-        self.assertEquals(self.ts.get_activities(slug="docudocs"),
+        self.assertEquals(self.ts.get_activities({"slug": "docudocs"}),
                           expected_result)
 
     def test_mock_get_activities_no_slug(self):

--- a/test_mock_pymesync.py
+++ b/test_mock_pymesync.py
@@ -278,7 +278,7 @@ class TestMockPymesync(unittest.TestCase):
             "uuid": "example-uuid"
         }]
 
-        self.assertEquals(self.ts.get_times(uuid="example-uuid"),
+        self.assertEquals(self.ts.get_times({"uuid": "example-uuid"}),
                           expected_result)
 
     def test_mock_get_times_no_uuid(self):

--- a/tests.py
+++ b/tests.py
@@ -861,7 +861,7 @@ class TestPymesync(unittest.TestCase):
                                                              self.ts.token)
 
         # Send it
-        self.ts.get_times(user=[self.ts.user])
+        self.ts.get_times({"user": [self.ts.user]})
 
         # Test that requests.get was called with baseurl and correct parameter
         requests.get.assert_called_with(url)
@@ -876,7 +876,7 @@ class TestPymesync(unittest.TestCase):
                                                        self.ts.token)
 
         # Send it
-        self.ts.get_times(project=["gwm"])
+        self.ts.get_times({"project": ["gwm"]})
 
         # Test that requests.get was called with baseurl and correct parameter
         requests.get.assert_called_with(url)
@@ -891,7 +891,7 @@ class TestPymesync(unittest.TestCase):
                                                         self.ts.token)
 
         # Send it
-        self.ts.get_times(activity=["dev"])
+        self.ts.get_times({"activity": ["dev"]})
 
         # Test that requests.get was called with baseurl and correct parameter
         requests.get.assert_called_with(url)
@@ -906,7 +906,7 @@ class TestPymesync(unittest.TestCase):
                                                             self.ts.token)
 
         # Send it
-        self.ts.get_times(start=["2015-07-23"])
+        self.ts.get_times({"start": ["2015-07-23"]})
 
         # Test that requests.get was called with baseurl and correct parameter
         requests.get.assert_called_with(url)
@@ -921,7 +921,7 @@ class TestPymesync(unittest.TestCase):
                                                           self.ts.token)
 
         # Send it
-        self.ts.get_times(end=["2015-07-23"])
+        self.ts.get_times({"end": ["2015-07-23"]})
 
         # Test that requests.get was called with baseurl and correct parameter
         requests.get.assert_called_with(url)
@@ -936,7 +936,7 @@ class TestPymesync(unittest.TestCase):
             self.ts.baseurl, self.ts.token)
 
         # Send it
-        self.ts.get_times(include_revisions=True)
+        self.ts.get_times({"include_revisions": True})
 
         # Test that requests.get was called with baseurl and correct parameter
         requests.get.assert_called_with(url)
@@ -952,7 +952,7 @@ class TestPymesync(unittest.TestCase):
             self.ts.baseurl, self.ts.token)
 
         # Send it
-        self.ts.get_times(include_revisions=False)
+        self.ts.get_times({"include_revisions": False})
 
         # Test that requests.get was called with baseurl and correct parameter
         requests.get.assert_called_with(url)
@@ -967,7 +967,7 @@ class TestPymesync(unittest.TestCase):
             self.ts.baseurl, self.ts.token)
 
         # Send it
-        self.ts.get_times(include_deleted=True)
+        self.ts.get_times({"include_deleted": True})
 
         # Test that requests.get was called with baseurl and correct parameter
         requests.get.assert_called_with(url)
@@ -983,7 +983,7 @@ class TestPymesync(unittest.TestCase):
             self.ts.baseurl, self.ts.token)
 
         # Send it
-        self.ts.get_times(include_deleted=False)
+        self.ts.get_times({"include_deleted": False})
 
         # Test that requests.get was called with baseurl and correct parameter
         requests.get.assert_called_with(url)
@@ -999,7 +999,7 @@ class TestPymesync(unittest.TestCase):
             self.ts.baseurl, self.ts.token)
 
         # Send it
-        self.ts.get_times(project=["gwm"], activity=["dev"])
+        self.ts.get_times({"project": ["gwm"], "activity": ["dev"]})
 
         # Test that requests.get was called with baseurl and correct parameters
         # Multiple parameters are sorted alphabetically
@@ -1018,7 +1018,7 @@ class TestPymesync(unittest.TestCase):
             self.ts.baseurl, token_string)
 
         # Send it
-        self.ts.get_times(activity=["dev", "rev", "hd"])
+        self.ts.get_times({"activity": ["dev", "rev", "hd"]})
 
         # Test that requests.get was called with baseurl and correct parameters
         # Multiple parameters are sorted alphabetically
@@ -1034,7 +1034,7 @@ class TestPymesync(unittest.TestCase):
                                                        self.ts.token)
 
         # Send it
-        self.ts.get_times(uuid="sadfasdg432")
+        self.ts.get_times({"uuid": "sadfasdg432"})
 
         # Test that requests.get was called with baseurl and correct parameter
         requests.get.assert_called_with(url)
@@ -1049,7 +1049,7 @@ class TestPymesync(unittest.TestCase):
                                                        self.ts.token)
 
         # Send it
-        self.ts.get_times(uuid="sadfasdg432", activity=["dev"])
+        self.ts.get_times({"uuid": "sadfasdg432", "activity": ["dev"]})
 
         # Test that requests.get was called with baseurl and correct parameter
         requests.get.assert_called_with(url)
@@ -1065,7 +1065,7 @@ class TestPymesync(unittest.TestCase):
             self.ts.baseurl, self.ts.token)
 
         # Send it
-        self.ts.get_times(uuid="sadfasdg432", include_revisions=True)
+        self.ts.get_times({"uuid": "sadfasdg432", "include_revisions": True})
 
         # Test that requests.get was called with baseurl and correct parameter
         requests.get.assert_called_with(url)
@@ -1081,7 +1081,7 @@ class TestPymesync(unittest.TestCase):
             self.ts.baseurl, self.ts.token)
 
         # Send it
-        self.ts.get_times(uuid="sadfasdg432", include_deleted=True)
+        self.ts.get_times({"uuid": "sadfasdg432", "include_deleted": True})
 
         # Test that requests.get was called with baseurl and correct parameter
         requests.get.assert_called_with(url)
@@ -1103,9 +1103,9 @@ class TestPymesync(unittest.TestCase):
                                            queries, token)
 
         # Send it
-        self.ts.get_times(uuid="sadfasdg432",
-                          include_revisions=True,
-                          include_deleted=True)
+        self.ts.get_times({"uuid": "sadfasdg432",
+                           "include_revisions": True,
+                           "include_deleted": True})
 
         # Test that requests.get was called with baseurl and correct parameter
         requests.get.assert_called_with(url)
@@ -1128,7 +1128,7 @@ class TestPymesync(unittest.TestCase):
     def test_get_times_bad_query(self):
         """Tests TimeSync.get_times with an invalid query parameter"""
         # Should return the error
-        self.assertEquals(self.ts.get_times(bad=["query"]),
+        self.assertEquals(self.ts.get_times({"bad": ["query"]}),
                           [{self.ts.error: "invalid query: bad"}])
 
     @patch("pymesync.TimeSync._TimeSync__response_to_python")

--- a/tests.py
+++ b/tests.py
@@ -1156,7 +1156,7 @@ class TestPymesync(unittest.TestCase):
                                                   self.ts.token)
 
         # Send it
-        self.ts.get_projects(slug="gwm")
+        self.ts.get_projects({"slug": "gwm"})
 
         # Test that requests.get was called correctly
         requests.get.assert_called_with(url)
@@ -1171,7 +1171,7 @@ class TestPymesync(unittest.TestCase):
             self.ts.baseurl, self.ts.token)
 
         # Send it
-        self.ts.get_projects(include_revisions=True)
+        self.ts.get_projects({"include_revisions": True})
 
         # Test that requests.get was called correctly
         requests.get.assert_called_with(url)
@@ -1186,7 +1186,7 @@ class TestPymesync(unittest.TestCase):
             self.ts.baseurl, self.ts.token)
 
         # Send it
-        self.ts.get_projects(slug="gwm", include_revisions=True)
+        self.ts.get_projects({"slug": "gwm", "include_revisions": True})
 
         # Test that requests.get was called correctly
         requests.get.assert_called_with(url)
@@ -1201,7 +1201,7 @@ class TestPymesync(unittest.TestCase):
             self.ts.baseurl, self.ts.token)
 
         # Send it
-        self.ts.get_projects(include_deleted=True)
+        self.ts.get_projects({"include_deleted": True})
 
         # Test that requests.get was called correctly
         requests.get.assert_called_with(url)
@@ -1214,16 +1214,16 @@ class TestPymesync(unittest.TestCase):
 
         # Test that error message is returned, can't combine slug and
         # include_deleted
-        self.assertEquals(self.ts.get_projects(slug="gwm",
-                                               include_deleted=True),
+        self.assertEquals(self.ts.get_projects({"slug": "gwm",
+                                                "include_deleted": True}),
                           [{self.ts.error:
                            "invalid combination: slug and include_deleted"}])
 
     @patch("pymesync.TimeSync._TimeSync__response_to_python")
     def test_get_projects_include_deleted_include_revisions(self,
                                                             m_resp_python):
-        """Tests TimeSync.get_projects with include_revisions and include_deleted
-        queries"""
+        """Tests TimeSync.get_projects with include_revisions and
+        include_deleted queries"""
         # Mock requests.get
         requests.get = mock.Mock("requests.get")
 
@@ -1233,7 +1233,8 @@ class TestPymesync(unittest.TestCase):
             self.ts.baseurl, endpoint, token_string)
 
         # Send it
-        self.ts.get_projects(include_revisions=True, include_deleted=True)
+        self.ts.get_projects({"include_revisions": True,
+                              "include_deleted": True})
 
         # Test that requests.get was called with correct parameters
         requests.get.assert_called_with(url)
@@ -1262,7 +1263,7 @@ class TestPymesync(unittest.TestCase):
                                                      self.ts.token)
 
         # Send it
-        self.ts.get_activities(slug="code")
+        self.ts.get_activities({"slug": "code"})
 
         # Test that requests.get was called correctly
         requests.get.assert_called_with(url)
@@ -1277,7 +1278,7 @@ class TestPymesync(unittest.TestCase):
             self.ts.baseurl, self.ts.token)
 
         # Send it
-        self.ts.get_activities(include_revisions=True)
+        self.ts.get_activities({"include_revisions": True})
 
         # Test that requests.get was called correctly
         requests.get.assert_called_with(url)
@@ -1292,7 +1293,7 @@ class TestPymesync(unittest.TestCase):
             self.ts.baseurl, self.ts.token)
 
         # Send it
-        self.ts.get_activities(slug="code", include_revisions=True)
+        self.ts.get_activities({"slug": "code", "include_revisions": True})
 
         # Test that requests.get was called correctly
         requests.get.assert_called_with(url)
@@ -1307,7 +1308,7 @@ class TestPymesync(unittest.TestCase):
             self.ts.baseurl, self.ts.token)
 
         # Send it
-        self.ts.get_activities(include_deleted=True)
+        self.ts.get_activities({"include_deleted": True})
 
         # Test that requests.get was called correctly
         requests.get.assert_called_with(url)
@@ -1320,8 +1321,8 @@ class TestPymesync(unittest.TestCase):
 
         # Test that error message is returned, can't combine slug and
         # include_deleted
-        self.assertEquals(self.ts.get_activities(slug="code",
-                                                 include_deleted=True),
+        self.assertEquals(self.ts.get_activities({"slug": "code",
+                                                  "include_deleted": True}),
                           [{self.ts.error:
                            "invalid combination: slug and include_deleted"}])
 
@@ -1339,7 +1340,8 @@ class TestPymesync(unittest.TestCase):
             self.ts.baseurl, endpoint, token_string)
 
         # Send it
-        self.ts.get_activities(include_revisions=True, include_deleted=True)
+        self.ts.get_activities({"include_revisions": True,
+                                "include_deleted": True})
 
         # Test that requests.get was called with correct parameters
         requests.get.assert_called_with(url)


### PR DESCRIPTION
See #98 for details.

Basically, this makes it so you can call `get_times` like this:
```
ts.get_times({"user": ["username1", "username2"]})
```
instead of like this:
```
ts.get_times(user=["username1", "username2"]})
```

The second option is easier to do by hand (via a CLI) but the first is easier to dynamically call because the dict can be dynamically created based on user input.

This functionality has been duplicated across ``get_projects`` and ``get_activities`` as well.