### PR TITLE
Create Method to Return Project Users

### DIFF
--- a/docs/source/developer.rst
+++ b/docs/source/developer.rst
@@ -42,7 +42,8 @@ filtering parameters can be passed to those methods that will get an unknown
 number of objects from TimeSync.
 
 The exception to this rule is for simple data returns like
-``token_expiration_time()`` which returns a python datetime.
+``token_expiration_time()``, which returns a python datetime, or
+``project_users()``, which return a python dictionary.
 
 Error Messages
 --------------

--- a/docs/source/testing.rst
+++ b/docs/source/testing.rst
@@ -152,6 +152,9 @@ An (almost) exhaustive example of test mode:
   >>> ts.delete_user(username="username")
   [{"status": 200}]
   >>>
+  >>> ts.project_users(project="ff")
+  {'malcolm': ['member', 'manager'], 'jayne': ['member'], 'kaylee': ['member'], 'zoe': ['member'], 'hoban': ['member'], 'simon': ['spectator'], 'river': ['spectator'], 'derrial': ['spectator'], 'inara': ['spectator']}
+  >>>
 
 
 .. _TimeSync API: http://timesync.readthedocs.org/en/latest/

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -71,7 +71,7 @@ Install pymesync
 Pymesync is on PyPi, so you can simply ``pip install pymesync``. We recommend
 you use `virtualenv`_, like so:
 
-.. code-block::
+.. code-block:: none
 
   virtualenv venv
   source venv/bin/activate
@@ -199,6 +199,20 @@ TimeSync.\ **token_expiration_time()**
       [{u'token': u'eyJ0eXAiOiJKV1QiLCJhbGciOiJITUFDLVNIQTUxMiJ9.eyJpc3MiOiJvc3Vvc2wtdGltZXN5bmMtc3RhZ2luZyIsInN1YiI6InRlc3QiLCJleHAiOjE0NTI3MTQzMzQwODcsImlhdCI6MTQ1MjcxMjUzNDA4N30=.QP2FbiY3I6e2eN436hpdjoBFbW9NdrRUHbkJ+wr9GK9mMW7/oC/oKnutCwwzMCwjzEx6hlxnGo6/LiGyPBcm3w=='}]
       >>> ts.token_expiration_time()
       datetime.datetime(2016, 1, 13, 11, 45, 34)
+      >>>
+
+TimeSync.\ **project_users(project)**
+
+    Returns a dictionary containing the user field of the specified project.
+
+    ``project`` is a string containing the desired project slug.
+
+    Example:
+
+    .. code-block:: python
+
+      >> ts.project_users(project="pyme")
+      {'malcolm': ['member', 'manager'], 'jayne': ['member'], 'kaylee': ['member'], 'zoe': ['member'], 'hoban': ['member'], 'simon': ['spectator'], 'river': ['spectator'], 'derrial': ['spectator'], 'inara': ['spectator']}
       >>>
 
 TimeSync.\ **create_time(time)**
@@ -331,7 +345,7 @@ TimeSync.\ **get_times(query_parameters=None)**
     an error message if unsuccessful.
 
     ``query_parameters`` is a python dictionary containing the optional query
-    parameters described in the `TimeSync documentation`_. If 
+    parameters described in the `TimeSync documentation`_. If
     ``query_parameters`` is missing, it defaults to ``None``, in which case
     ``get_times()`` will return all times the current user is authorized to see.
     The syntax for each argument is ``{"query": ["parameter1", "parameter2"]}``

--- a/pymesync/mock_pymesync.py
+++ b/pymesync/mock_pymesync.py
@@ -379,3 +379,20 @@ def get_users(username):
 def delete_object():
     """Delete an object from TimeSync"""
     return [{"status": 200}]
+
+
+def project_users():
+    """Return list of users and permissions from TimeSync"""
+    users = {
+        u'malcolm': [u'member', u'manager'],
+        u'jayne':   [u'member'],
+        u'kaylee':  [u'member'],
+        u'zoe':     [u'member'],
+        u'hoban':   [u'member'],
+        u'simon':   [u'spectator'],
+        u'river':   [u'spectator'],
+        u'derrial': [u'spectator'],
+        u'inara':   [u'spectator']
+    }
+
+    return [users]

--- a/pymesync/mock_pymesync.py
+++ b/pymesync/mock_pymesync.py
@@ -395,4 +395,4 @@ def project_users():
         u'inara':   [u'spectator']
     }
 
-    return [users]
+    return users

--- a/pymesync/test_mock_pymesync.py
+++ b/pymesync/test_mock_pymesync.py
@@ -542,6 +542,25 @@ class TestMockPymesync(unittest.TestCase):
         self.assertEquals(self.ts.delete_activity("junk"), [{"status": 200}])
         self.assertEquals(self.ts.delete_user("junk"), [{"status": 200}])
 
+    def test_mock_project_users(self):
+        expected_result = {
+            'malcolm': ['member', 'manager'],
+            'jayne': ['member'],
+            'kaylee': ['member'],
+            'zoe': ['member'],
+            'hoban': ['member'],
+            'simon': ['spectator'],
+            'river': ['spectator'],
+            'derrial': ['spectator'],
+            'inara': ['spectator']
+        }
+        self.assertEquals(self.ts.project_users(project="ff"), expected_result)
+
+    def test_mock_project_users_no_slug(self):
+        expected_result = {self.ts.error: "Missing project slug, please"
+                                          "include in method call"}
+        self.assertEquals(self.ts.project_users(), expected_result)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/pymesync/test_mock_pymesync.py
+++ b/pymesync/test_mock_pymesync.py
@@ -543,7 +543,7 @@ class TestMockPymesync(unittest.TestCase):
         self.assertEquals(self.ts.delete_user("junk"), [{"status": 200}])
 
     def test_mock_project_users(self):
-        expected_result = [{
+        expected_result = {
             u'malcolm': [u'member', u'manager'],
             u'jayne':   [u'member'],
             u'kaylee':  [u'member'],
@@ -553,7 +553,7 @@ class TestMockPymesync(unittest.TestCase):
             u'river':   [u'spectator'],
             u'derrial': [u'spectator'],
             u'inara':   [u'spectator']
-        }]
+        }
 
         self.assertEquals(self.ts.project_users(project="ff"), expected_result)
 

--- a/pymesync/test_mock_pymesync.py
+++ b/pymesync/test_mock_pymesync.py
@@ -543,22 +543,23 @@ class TestMockPymesync(unittest.TestCase):
         self.assertEquals(self.ts.delete_user("junk"), [{"status": 200}])
 
     def test_mock_project_users(self):
-        expected_result = {
-            'malcolm': ['member', 'manager'],
-            'jayne': ['member'],
-            'kaylee': ['member'],
-            'zoe': ['member'],
-            'hoban': ['member'],
-            'simon': ['spectator'],
-            'river': ['spectator'],
-            'derrial': ['spectator'],
-            'inara': ['spectator']
-        }
+        expected_result = [{
+            u'malcolm': [u'member', u'manager'],
+            u'jayne':   [u'member'],
+            u'kaylee':  [u'member'],
+            u'zoe':     [u'member'],
+            u'hoban':   [u'member'],
+            u'simon':   [u'spectator'],
+            u'river':   [u'spectator'],
+            u'derrial': [u'spectator'],
+            u'inara':   [u'spectator']
+        }]
+
         self.assertEquals(self.ts.project_users(project="ff"), expected_result)
 
     def test_mock_project_users_no_slug(self):
-        expected_result = {self.ts.error: "Missing project slug, please"
-                                          "include in method call"}
+        expected_result = [{self.ts.error: "Missing project slug, please "
+                                           "include in method call"}]
         self.assertEquals(self.ts.project_users(), expected_result)
 
 

--- a/pymesync/tests.py
+++ b/pymesync/tests.py
@@ -14,7 +14,6 @@ class resp(object):
     def __init__(self):
         self.text = None
         self.status_code = None
-        self.error = None
 
 
 class TestPymesync(unittest.TestCase):
@@ -1515,7 +1514,7 @@ class TestPymesync(unittest.TestCase):
 
     def test_response_to_python_empty_response(self):
         """Check that __response_to_python returns correctly for delete_*
-        methods"""
+G       methods"""
         response = resp()
         response.text = ""
         response.status_code = 200
@@ -2199,58 +2198,58 @@ class TestPymesync(unittest.TestCase):
         project = "pyme"
         response = resp()
         response.status_code = 200
-        response.text = "{\
-            'uri': 'https://github.com/osuosl/pymesync',\
-            'name': 'pymesync',\
-            'slugs': ['pyme', 'ps', 'pymesync'],\
-            'uuid': 'a034806c-00db-4fe1-8de8-514575f31bfb',\
-            'revision': 4,\
-            'created_at': '2014-07-17',\
-            'deleted_at': null,\
-            'updated_at': '2014-07-20',\
-            'users': {\
-                'malcolm': {'member': true,\
-                            'manager': true,\
-                            'spectator': false},\
-                'jayne':   {'member': true,\
-                            'manager': false,\
-                            'spectator': false},\
-                'kaylee':  {'member': true,\
-                            'manager': false,\
-                            'spectator': false},\
-                'zoe':     {'member': true,\
-                            'manager': false,\
-                            'spectator: false},\
-                'hoban':   {'member': true,\
-                            'manager': false,\
-                            'spectator': false},\
-                'simon':   {'member': false,\
-                            'manager': false,\
-                            'spectator': true},\
-                'river':   {'member': false,\
-                            'manager': false,\
-                            'spectator': true},\
-                'derrial': {'member': false,\
-                            'manager': false,\
-                            'spectator': true},\
-                'inara':   {'member': false,\
-                            'manager': false,\
-                            'spectator': false}\
-            }\
-        }"
+        response.text = json.dumps({
+            "uri": "https://github.com/osuosl/pymesync",
+            "name": "pymesync",
+            "slugs": ["pyme", "ps", "pymesync"],
+            "uuid": "a034806c-00db-4fe1-8de8-514575f31bfb",
+            "revision": 4,
+            "created_at": "2014-07-17",
+            "deleted_at": None,
+            "updated_at": "2014-07-20",
+            "users": {
+                "malcolm": {"member": True,
+                            "manager": True,
+                            "spectator": True},
+                "jayne":   {"member": True,
+                            "manager": False,
+                            "spectator": False},
+                "kaylee":  {"member": True,
+                            "manager": False,
+                            "spectator": False},
+                "zoe":     {"member": True,
+                            "manager": False,
+                            "spectator": False},
+                "hoban":   {"member": True,
+                            "manager": False,
+                            "spectator": False},
+                "simon":   {"member": False,
+                            "manager": False,
+                            "spectator": True},
+                "river":   {"member": False,
+                            "manager": False,
+                            "spectator": True},
+                "derrial": {"member": False,
+                            "manager": False,
+                            "spectator": True},
+                "inara":   {"member": False,
+                            "manager": False,
+                            "spectator": True}
+            }
+        })
         expected_result = {
-            'malcolm': ['member', 'manager'],
-            'jayne': ['member'],
-            'kaylee': ['member'],
-            'zoe': ['member'],
-            'hoban': ['member'],
-            'simon': ['spectator'],
-            'river': ['spectator'],
-            'derrial': ['spectator'],
-            'inara': ['spectator']
+            u'malcolm': [u'member', u'manager', u'spectator'],
+            u'jayne':   [u'member'],
+            u'kaylee':  [u'member'],
+            u'zoe':     [u'member'],
+            u'hoban':   [u'member'],
+            u'simon':   [u'spectator'],
+            u'river':   [u'spectator'],
+            u'derrial': [u'spectator'],
+            u'inara':   [u'spectator']
         }
 
-        # Mock requests.post so it doesn't actually post to TimeSync
+        # Mock requests.get so it doesn't actually post to TimeSync
         requests.get = mock.create_autospec(requests.get,
                                             return_value=response)
 
@@ -2260,26 +2259,28 @@ class TestPymesync(unittest.TestCase):
     def test_project_users_error_response(self):
         """Test project_users method with an error object returned from
         TimeSync"""
-        project = "pymes"
+        proj = "pymes"
         response = resp()
         response.status_code = 404
-        response.error = "Object not found"
-        response.text = "Nonexistent project"
-        expected_result = {self.ts.error: "project pymes does not exist"}
+        response.text = json.dumps({
+            "error": "Object not found",
+            "text": "Nonexistent project"
+        })
 
-        # Mock requests.post so it doesn't actually post to TimeSync
+        # Mock requests.get so it doesn't actually post to TimeSync
         requests.get = mock.create_autospec(requests.get,
                                             return_value=response)
 
-        self.assertEquals(self.ts.project_users(project=project),
-                          expected_result)
+        self.assertEquals(self.ts.project_users(project=proj),
+                          [{u"error": u"Object not found",
+                            u"text": u"Nonexistent project"}])
 
     def test_project_users_no_project_parameter(self):
         """Test project_users method with no project object passed as a
         parameter, should return an error"""
         self.assertEquals(self.ts.project_users(),
-                          {self.ts.error: "Missing project slug, please"
-                                          "include in method call"})
+                          [{self.ts.error: "Missing project slug, please "
+                                           "include in method call"}])
 
 if __name__ == "__main__":
     actual_post = requests.post  # Save this for testing exceptions

--- a/pymesync/tests.py
+++ b/pymesync/tests.py
@@ -2209,15 +2209,34 @@ class TestPymesync(unittest.TestCase):
             'deleted_at': null,\
             'updated_at': '2014-07-20',\
             'users': {\
-                'malcolm': ['member', 'manager'],\
-                'jayne': ['member'],\
-                'kaylee': ['member'],\
-                'zoe': ['member'],\
-                'hoban': ['member'],\
-                'simon': ['spectator'],\
-                'river': ['spectator'],\
-                'derrial': ['spectator'],\
-                'inara': ['spectator']}\
+                'malcolm': {'member': true,\
+                            'manager': true,\
+                            'spectator': false},\
+                'jayne':   {'member': true,\
+                            'manager': false,\
+                            'spectator': false},\
+                'kaylee':  {'member': true,\
+                            'manager': false,\
+                            'spectator': false},\
+                'zoe':     {'member': true,\
+                            'manager': false,\
+                            'spectator: false},\
+                'hoban':   {'member': true,\
+                            'manager': false,\
+                            'spectator': false},\
+                'simon':   {'member': false,\
+                            'manager': false,\
+                            'spectator': true},\
+                'river':   {'member': false,\
+                            'manager': false,\
+                            'spectator': true},\
+                'derrial': {'member': false,\
+                            'manager': false,\
+                            'spectator': true},\
+                'inara':   {'member': false,\
+                            'manager': false,\
+                            'spectator': false}\
+            }\
         }"
         expected_result = {
             'malcolm': ['member', 'manager'],
@@ -2261,122 +2280,6 @@ class TestPymesync(unittest.TestCase):
         self.assertEquals(self.ts.project_users(),
                           {self.ts.error: "Missing project slug, please"
                                           "include in method call"})
-
-    def test_project_users_valid_manager(self):
-        """Test project_users method with a valid project object returned from
-        TimeSync and user_type = manager"""
-        project = "pyme"
-        response = resp()
-        response.status_code = 200
-        response.text = "{\
-            'uri': 'https://github.com/osuosl/pymesync',\
-            'name': 'pymesync',\
-            'slugs': ['pyme', 'ps', 'pymesync'],\
-            'uuid': 'a034806c-00db-4fe1-8de8-514575f31bfb',\
-            'revision': 4,\
-            'created_at': '2014-07-17',\
-            'deleted_at': null,\
-            'updated_at': '2014-07-20',\
-            'users': {\
-                'malcolm': ['member', 'manager'],\
-                'jayne': ['member'],\
-                'kaylee': ['member'],\
-                'zoe': ['member'],\
-                'hoban': ['member'],\
-                'simon': ['spectator'],\
-                'river': ['spectator'],\
-                'derrial': ['spectator'],\
-                'inara': ['spectator']}\
-        }"
-        expected_result = ['malcolm']
-
-        # Mock requests.post so it doesn't actually post to TimeSync
-        requests.get = mock.create_autospec(requests.get,
-                                            return_value=response)
-
-        self.assertEquals(self.ts.project_users(project=project,
-                                                user_type="manager"),
-                          expected_result)
-
-    def test_project_users_valid_member(self):
-        """Test project_users method with a valid project object returned from
-        TimeSync and user_type = member"""
-        project = "pyme"
-        response = resp()
-        response.status_code = 200
-        response.text = "{\
-            'uri': 'https://github.com/osuosl/pymesync',\
-            'name': 'pymesync',\
-            'slugs': ['pyme', 'ps', 'pymesync'],\
-            'uuid': 'a034806c-00db-4fe1-8de8-514575f31bfb',\
-            'revision': 4,\
-            'created_at': '2014-07-17',\
-            'deleted_at': null,\
-            'updated_at': '2014-07-20',\
-            'users': {\
-                'malcolm': ['member', 'manager'],\
-                'jayne': ['member'],\
-                'kaylee': ['member'],\
-                'zoe': ['member'],\
-                'hoban': ['member'],\
-                'simon': ['spectator'],\
-                'river': ['spectator'],\
-                'derrial': ['spectator'],\
-                'inara': ['spectator']}\
-        }"
-        expected_result = ['malcolm', 'jayne', 'kaylee', 'zoe', 'hoban']
-
-        # Mock requests.post so it doesn't actually post to TimeSync
-        requests.get = mock.create_autospec(requests.get,
-                                            return_value=response)
-
-        self.assertEquals(self.ts.project_users(project=project,
-                                                user_type="member"),
-                          expected_result)
-
-    def test_project_users_valid_spectator(self):
-        """Test project_users method with a valid project object returned from
-        TimeSync"""
-        project = "pyme"
-        response = resp()
-        response.status_code = 200
-        response.text = "{\
-            'uri': 'https://github.com/osuosl/pymesync',\
-            'name': 'pymesync',\
-            'slugs': ['pyme', 'ps', 'pymesync'],\
-            'uuid': 'a034806c-00db-4fe1-8de8-514575f31bfb',\
-            'revision': 4,\
-            'created_at': '2014-07-17',\
-            'deleted_at': null,\
-            'updated_at': '2014-07-20',\
-            'users': {\
-                'malcolm': ['member', 'manager'],\
-                'jayne': ['member'],\
-                'kaylee': ['member'],\
-                'zoe': ['member'],\
-                'hoban': ['member'],\
-                'simon': ['spectator'],\
-                'river': ['spectator'],\
-                'derrial': ['spectator'],\
-                'inara': ['spectator']}\
-        }"
-        expected_result = ['simon', 'river', 'derrial', 'inara']
-
-        # Mock requests.post so it doesn't actually post to TimeSync
-        requests.get = mock.create_autospec(requests.get,
-                                            return_value=response)
-
-        self.assertEquals(self.ts.project_users(project=project,
-                                                user_type="spectator"),
-                          expected_result)
-
-    def test_project_users_bad_user_type_parameter(self):
-        """Test project_users method with no project object passed as a
-        parameter, should return an error"""
-        self.assertEquals(self.ts.project_users(project="pyme",
-                                                user_type="bad"),
-                          {self.ts.error: "invalid user_type bad, must be "
-                                          "manager, member, or spectator"})
 
 if __name__ == "__main__":
     actual_post = requests.post  # Save this for testing exceptions

--- a/pymesync/tests.py
+++ b/pymesync/tests.py
@@ -2262,6 +2262,122 @@ class TestPymesync(unittest.TestCase):
                           {self.ts.error: "Missing project slug, please"
                                           "include in method call"})
 
+    def test_project_users_valid_manager(self):
+        """Test project_users method with a valid project object returned from
+        TimeSync and user_type = manager"""
+        project = "pyme"
+        response = resp()
+        response.status_code = 200
+        response.text = "{\
+            'uri': 'https://github.com/osuosl/pymesync',\
+            'name': 'pymesync',\
+            'slugs': ['pyme', 'ps', 'pymesync'],\
+            'uuid': 'a034806c-00db-4fe1-8de8-514575f31bfb',\
+            'revision': 4,\
+            'created_at': '2014-07-17',\
+            'deleted_at': null,\
+            'updated_at': '2014-07-20',\
+            'users': {\
+                'malcolm': ['member', 'manager'],\
+                'jayne': ['member'],\
+                'kaylee': ['member'],\
+                'zoe': ['member'],\
+                'hoban': ['member'],\
+                'simon': ['spectator'],\
+                'river': ['spectator'],\
+                'derrial': ['spectator'],\
+                'inara': ['spectator']}\
+        }"
+        expected_result = ['malcolm']
+
+        # Mock requests.post so it doesn't actually post to TimeSync
+        requests.get = mock.create_autospec(requests.get,
+                                            return_value=response)
+
+        self.assertEquals(self.ts.project_users(project=project,
+                                                user_type="manager"),
+                          expected_result)
+
+    def test_project_users_valid_member(self):
+        """Test project_users method with a valid project object returned from
+        TimeSync and user_type = member"""
+        project = "pyme"
+        response = resp()
+        response.status_code = 200
+        response.text = "{\
+            'uri': 'https://github.com/osuosl/pymesync',\
+            'name': 'pymesync',\
+            'slugs': ['pyme', 'ps', 'pymesync'],\
+            'uuid': 'a034806c-00db-4fe1-8de8-514575f31bfb',\
+            'revision': 4,\
+            'created_at': '2014-07-17',\
+            'deleted_at': null,\
+            'updated_at': '2014-07-20',\
+            'users': {\
+                'malcolm': ['member', 'manager'],\
+                'jayne': ['member'],\
+                'kaylee': ['member'],\
+                'zoe': ['member'],\
+                'hoban': ['member'],\
+                'simon': ['spectator'],\
+                'river': ['spectator'],\
+                'derrial': ['spectator'],\
+                'inara': ['spectator']}\
+        }"
+        expected_result = ['malcolm', 'jayne', 'kaylee', 'zoe', 'hoban']
+
+        # Mock requests.post so it doesn't actually post to TimeSync
+        requests.get = mock.create_autospec(requests.get,
+                                            return_value=response)
+
+        self.assertEquals(self.ts.project_users(project=project,
+                                                user_type="member"),
+                          expected_result)
+
+    def test_project_users_valid_spectator(self):
+        """Test project_users method with a valid project object returned from
+        TimeSync"""
+        project = "pyme"
+        response = resp()
+        response.status_code = 200
+        response.text = "{\
+            'uri': 'https://github.com/osuosl/pymesync',\
+            'name': 'pymesync',\
+            'slugs': ['pyme', 'ps', 'pymesync'],\
+            'uuid': 'a034806c-00db-4fe1-8de8-514575f31bfb',\
+            'revision': 4,\
+            'created_at': '2014-07-17',\
+            'deleted_at': null,\
+            'updated_at': '2014-07-20',\
+            'users': {\
+                'malcolm': ['member', 'manager'],\
+                'jayne': ['member'],\
+                'kaylee': ['member'],\
+                'zoe': ['member'],\
+                'hoban': ['member'],\
+                'simon': ['spectator'],\
+                'river': ['spectator'],\
+                'derrial': ['spectator'],\
+                'inara': ['spectator']}\
+        }"
+        expected_result = ['simon', 'river', 'derrial', 'inara']
+
+        # Mock requests.post so it doesn't actually post to TimeSync
+        requests.get = mock.create_autospec(requests.get,
+                                            return_value=response)
+
+        self.assertEquals(self.ts.project_users(project=project,
+                                                user_type="spectator"),
+                          expected_result)
+
+    def test_project_users_bad_user_type_parameter(self):
+        """Test project_users method with no project object passed as a
+        parameter, should return an error"""
+        self.assertEquals(self.ts.project_users(project="pyme",
+                                                user_type="bad"),
+                          {self.ts.error: "invalid user_type bad, must be "
+                                          "manager, member, or spectator"})
+
 if __name__ == "__main__":
     actual_post = requests.post  # Save this for testing exceptions
     actual_delete = requests.delete


### PR DESCRIPTION
Ref #102 

Specifically, implementing the first return option:
```
>>> ts.project_users(project="ff")
{'malcolm': ['member', 'manager'], 'jayne': ['member'], 'kaylee': ['member'], 'zoe': ['member'], 'hoban': ['member'], 'simon': ['spectator'], 'river': ['spectator'], 'derrial': ['spectator'], 'inara': ['spectator']}
```

And the functionality of the last option:
```
>>> ts.project_users(project="ff", type="manager")
['malcolm']
```