### PR TITLE
Refactor Return Types **BIG CHANGES**

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -25,6 +25,7 @@ To test the source code:
 
 .. code-block::
 
+  (venv) $ cd pymesync   # pymesync subdirectory holds the source code
   (venv) $ make test
   (venv) $ make flake    # Runs flake8 on pymesync.py and tests.py
 

--- a/docs/source/developer.rst
+++ b/docs/source/developer.rst
@@ -30,10 +30,11 @@ described in the next section.
 Return Format
 -------------
 
-Pymesync (almost) **always** returns a list of one or more python dictionaries.
-
-This allows the user to access information using array notation for every
-method. Even error messages are returned in this manner.
+Pymesync usually returns a dictionary or a list of zero or more python
+dictionaries (in the case of get methods). The return format is decided by the
+information that will be returned by TimeSync. If TimeSync could return
+multiple objects, Pymesync returns the dicts in a list, even if zero or one
+object is returned.
 
 Following this format, the user can use the same logic and syntax to process a
 ``get_<endpoint>()`` method that returns one object as they do for a
@@ -42,18 +43,20 @@ filtering parameters can be passed to those methods that will get an unknown
 number of objects from TimeSync.
 
 The exception to this rule is for simple data returns like
-``token_expiration_time()``, which returns a python datetime, or
-``project_users()``, which return a python dictionary.
+``token_expiration_time()``, which returns a python datetime. 
 
 Error Messages
 --------------
 
-As mentioned above, local pymesync error messages should be returned as a
-python dictionary within a list. The key for the error message is set as a class
-variable in the ``pymesync.TimeSync`` class constructor. This class variable is
-called ``error`` and sets the key name throughout the module, including in the
-tests. The value stored at the key location must be descriptive enough to help
-the user debug their issue.
+Local pymesync error messages and TimeSync error messages returned from the API
+should be returned in the same format as their parent method. Simple data
+returns such as ``token_expiration_time()`` should return a python dictionary.
+
+The key for the error message is set as a class variable in the
+``pymesync.TimeSync`` class constructor. This class variable is called
+``error`` and sets the key name throughout the module, including in the tests.
+The value stored at the key location must be descriptive enough to help the
+user debug their issue.
 
 The TimeSync API also returns its own errors in a different format, like so:
 

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -26,8 +26,8 @@ Pymesync currently supports the following TimeSync API versions:
 
 * v1
 
-All of these methods return a list of one or more python dictionaries (or an
-empty list if TimeSync has no records).
+All of these methods return a python dictionary (or a list of zero or more
+python dictionaries in the case of the ``get_*`` methods).
 
 * **authenticate(username, password, auth_type)** - Authenticates a pymesync
   object with a TimeSync implementation
@@ -120,20 +120,21 @@ of code.
 .. note::
 
   If you attempt to get, create, or update objects before authenticating,
-  pymesync will return this error:
+  pymesync will return this error (get methods will return this error nested in
+  a list):
 
   .. code-block:: python
 
-    [{"pymesync error": "Not authenticated with TimeSync, call self.authenticate() first"}]
+    {"pymesync error": "Not authenticated with TimeSync, call self.authenticate() first"}
 
 Errors
 ------
 
-Pymesync returns errors the same way it returns successes for whatever method is
-in use. This means that most of the time errors are returned as a Python
-dictionary inside a list. If the error is a local pymesync error, the
-key for the error message will be ``"pymesync error"``. If the error is from
-TimeSync, the dictionary will contain the same keys described in the
+Pymesync returns errors the same way it returns successes for whatever method
+is in use. This means that most of the time errors are returned as a Python
+dictionary, except in the case of get methods. If the error is a local pymesync
+error, the key for the error message will be ``"pymesync error"``. If the error
+is from TimeSync, the dictionary will contain the same keys described in the
 `TimeSync error documentation`_, but as a python dictionary.
 
 If there is an error connecting with the TimeSync instance specified by the
@@ -174,25 +175,25 @@ TimeSync.\ **authenticate(user, password, auth_type)**
     TimeSync implementation uses for login, such as ``"password"``, or
     ``"ldap"``.
 
-    **authenticate()** will return a list containing a python dictionary. If
-    authentication was successful, the list will look like this:
+    **authenticate()** will return a python dictionary. If authentication was 
+    successful, the dictionary will look like this:
 
     .. code-block:: python
 
-      [{"token": "SOMELONGTOKEN"}]
+      {"token": "SOMELONGTOKEN"}
 
-    If authentication was unsuccessful, the list will contain an error message:
+    If authentication was unsuccessful, the dict will contain an error message:
 
     .. code-block:: python
 
-      [{"status": 401, "error": "Authentication failure", "text": "Invalid username or password"}]
+      {"status": 401, "error": "Authentication failure", "text": "Invalid username or password"}
 
     Example:
 
     .. code-block:: python
 
       >>> ts.authenticate(username="example-user", password="example-password", auth_type="password")
-      [{u'token': u'eyJ0eXAi...XSnv0ghQ=='}]
+      {u'token': u'eyJ0eXAi...XSnv0ghQ=='}
       >>>
 
 TimeSync.\ **token_expiration_time()**
@@ -200,12 +201,14 @@ TimeSync.\ **token_expiration_time()**
     Returns a python datetime representing the expiration time of the current
     authentication token.
 
+    If an error occurs, the error is returned in a single python dict.
+
     Example:
 
     .. code-block:: python
 
       >>> ts.authenticate(username="username", password="user-pass", auth_type="password")
-      [{u'token': u'eyJ0eXAiOiJKV1QiLCJhbGciOiJITUFDLVNIQTUxMiJ9.eyJpc3MiOiJvc3Vvc2wtdGltZXN5bmMtc3RhZ2luZyIsInN1YiI6InRlc3QiLCJleHAiOjE0NTI3MTQzMzQwODcsImlhdCI6MTQ1MjcxMjUzNDA4N30=.QP2FbiY3I6e2eN436hpdjoBFbW9NdrRUHbkJ+wr9GK9mMW7/oC/oKnutCwwzMCwjzEx6hlxnGo6/LiGyPBcm3w=='}]
+      {u'token': u'eyJ0eXAiOiJKV1QiLCJhbGciOiJITUFDLVNIQTUxMiJ9.eyJpc3MiOiJvc3Vvc2wtdGltZXN5bmMtc3RhZ2luZyIsInN1YiI6InRlc3QiLCJleHAiOjE0NTI3MTQzMzQwODcsImlhdCI6MTQ1MjcxMjUzNDA4N30=.QP2FbiY3I6e2eN436hpdjoBFbW9NdrRUHbkJ+wr9GK9mMW7/oC/oKnutCwwzMCwjzEx6hlxnGo6/LiGyPBcm3w=='}
       >>> ts.token_expiration_time()
       datetime.datetime(2016, 1, 13, 11, 45, 34)
       >>>
@@ -221,16 +224,15 @@ TimeSync.\ **project_users(project)**
     .. code-block:: python
 
       >> ts.project_users(project="pyme")
-      {'malcolm': ['member', 'manager'], 'jayne': ['member'], 'kaylee': ['member'], 'zoe': ['member'], 'hoban': ['member'], 'simon': ['spectator'], 'river': ['spectator'], 'derrial': ['spectator'], 'inara': ['spectator']}
+      {u'malcolm': [u'member', u'manager'], u'jayne': [u'member'], u'kaylee': [u'member'], u'zoe': [u'member'], u'hoban': [u'member'], u'simon': [u'spectator'], u'river': [u'spectator'], u'derrial': [u'spectator'], u'inara': [u'spectator']}
       >>>
 
 TimeSync.\ **create_time(time)**
 
     Send a time entry to the TimeSync instance at the baseurl provided when
-    instantiating the TimeSync object. This method will return a list with
-    a single python dictionary containing the created entry if successful. The
-    dictionary will contain error information if ``create_time()`` was
-    unsuccessful.
+    instantiating the TimeSync object. This method will return a single python
+    dictionary containing the created entry if successful. The dictionary will
+    contain error information if ``create_time()`` was unsuccessful.
 
     ``time`` is a python dictionary containing the time information to send to
     TimeSync. The syntax is ``"string_key": "string_value"`` with the exception
@@ -271,7 +273,7 @@ TimeSync.\ **create_time(time)**
       ...    "date_worked": "2014-04-17"
       ...}
       >>> ts.create_time(time=time)
-      [{'activities': ['docs'], 'deleted_at': None, 'date_worked': '2014-04-17', 'uuid': '838853e3-3635-4076-a26f-7efr4e60981f', 'notes': 'Worked on documentation toward settings configuration.', 'updated_at': None, 'project': 'ganeti_web_manager', 'user': 'example-2', 'duration': 1200, 'issue_uri': 'https://github.com/osuosl/ganeti_webmgr/issues', 'created_at': '2015-05-23', 'revision': 1}]
+      {u'activities': [u'docs'], u'deleted_at': None, u'date_worked': u'2014-04-17', u'uuid': u'838853e3-3635-4076-a26f-7efr4e60981f', u'notes': u'Worked on documentation toward settings configuration.', u'updated_at': None, u'project': u'ganeti_web_manager', u'user': u'example-2', u'duration': 1200, u'issue_uri': u'https://github.com/osuosl/ganeti_webmgr/issues', u'created_at': u'2015-05-23', u'revision': 1}
       >>>
 
     .. code-block:: python
@@ -286,7 +288,7 @@ TimeSync.\ **create_time(time)**
       ...    "date_worked": "2014-04-17"
       ...}
       >>> ts.create_time(time=time)
-      [{'activities': ['docs'], 'deleted_at': None, 'date_worked': '2014-04-17', 'uuid': '838853e3-3635-4076-a26f-7efr4e60981f', 'notes': 'Worked on documentation toward settings configuration.', 'updated_at': None, 'project': 'ganeti_web_manager', 'user': 'example-2', 'duration': 12600, 'issue_uri': 'https://github.com/osuosl/ganeti_webmgr/issues', 'created_at': '2015-05-23', 'revision': 1}]
+      {u'activities': [u'docs'], u'deleted_at': None, u'date_worked': u'2014-04-17', u'uuid': u'838853e3-3635-4076-a26f-7efr4e60981f', u'notes': u'Worked on documentation toward settings configuration.', u'updated_at': None, u'project': u'ganeti_web_manager', u'user': u'example-2', u'duration': 12600, u'issue_uri': u'https://github.com/osuosl/ganeti_webmgr/issues', u'created_at': u'2015-05-23', u'revision': 1}
       >>>
 
 ------------------------------------------
@@ -295,9 +297,9 @@ TimeSync.\ **update_time(time, uuid)**
 
     Update a time entry by uuid on the TimeSync instance specified by the
     baseurl provided when instantiating the TimeSync object. This method will
-    return a list with a single python dictionary containing the updated entry
-    if successful. The dictionary will contain error information if
-    ``update_time()`` was unsuccessful.
+    return a python dictionary containing the updated entry if successful. The
+    dictionary will contain error information if ``update_time()`` was
+    unsuccessful.
 
     ``time`` is a python dictionary containing the time information to send to
     TimeSync. The syntax is ``"string_key": "string_value"`` with the exception
@@ -333,7 +335,7 @@ TimeSync.\ **update_time(time, uuid)**
       ...    "activities": ["hello", "world"],
       ...}
       >>> ts.update_time(time=time, uuid="some-uuid")
-      [{'activities': ['hello', 'world'], 'date_worked': '2015-08-07', 'updated_at': '2015-10-18', 'user': 'red-leader', 'duration': 1900, 'deleted_at': None, 'uuid': 'some-uuid', 'notes': None, 'project': ['ganeti'], 'issue_uri': 'https://github.com/osuosl/ganeti_webmgr/issues/56', 'created_at': '2014-06-12', 'revision': 2}]
+      {u'activities': [u'hello', u'world'], u'date_worked': u'2015-08-07', u'updated_at': u'2015-10-18', u'user': u'red-leader', u'duration': 1900, u'deleted_at': None, u'uuid': u'some-uuid', u'notes': None, u'project': [u'ganeti'], u'issue_uri': u'https://github.com/osuosl/ganeti_webmgr/issues/56', u'created_at': u'2014-06-12', u'revision': 2}
 
       >>> time = {
       ...    "duration": "3h35m",
@@ -341,7 +343,7 @@ TimeSync.\ **update_time(time, uuid)**
       ...    "activities": ["hello", "world"],
       ...}
       >>> ts.update_time(time=time, uuid="some-uuid")
-      [{'activities': ['hello', 'world'], 'date_worked': '2015-08-07', 'updated_at': '2015-10-18', 'user': 'red-leader', 'duration': 12900, 'deleted_at': None, 'uuid': 'some-uuid', 'notes': None, 'project': ['ganeti'], 'issue_uri': 'https://github.com/osuosl/ganeti_webmgr/issues/56', 'created_at': '2014-06-12', 'revision': 3}]
+      {u'activities': [u'hello', u'world'], u'date_worked': u'2015-08-07', u'updated_at': u'2015-10-18', u'user': u'red-leader', u'duration': 12900, u'deleted_at': None, u'uuid': u'some-uuid', u'notes': None, u'project': [u'ganeti'], u'issue_uri': u'https://github.com/osuosl/ganeti_webmgr/issues/56', u'created_at': u'2014-06-12', u'revision': 3}
 
 ------------------------------------------
 
@@ -406,15 +408,15 @@ TimeSync.\ **get_times(query_parameters=None)**
     .. code-block:: python
 
       >>> ts.get_times()
-      [{'activities': ['docs', 'planning'], 'date_worked': '2014-04-17', 'updated_at': None, 'user': 'userone', 'duration': 1200, 'deleted_at': None, 'uuid': 'c3706e79-1c9a-4765-8d7f-89b4544cad56', 'notes': 'Worked on documentation.', 'project': ['ganeti-webmgr', 'gwm'], 'issue_uri': 'https://github.com/osuosl/ganeti_webmgr', 'created_at': '2014-04-17', 'revision': 1}, {'activities': ['code', 'planning'], 'date_worked': '2014-04-17', 'updated_at': None, 'user': 'usertwo', 'duration': 1300, 'deleted_at': None, 'uuid': '12345676-1c9a-rrrr-bbbb-89b4544cad56', 'notes': 'Worked on coding', 'project': ['ganeti-webmgr', 'gwm'], 'issue_uri': 'https://github.com/osuosl/ganeti_webmgr', 'created_at': '2014-04-17', 'revision': 1}, {'activities': ['code'], 'date_worked': '2014-04-17', 'updated_at': None, 'user': 'userthree', 'duration': 1400, 'deleted_at': None, 'uuid': '12345676-1c9a-ssss-cccc-89b4544cad56', 'notes': 'Worked on coding', 'project': ['timesync', 'ts'], 'issue_uri': 'https://github.com/osuosl/timesync', 'created_at': '2014-04-17', 'revision': 1}]
+      [{u'activities': [u'docs', u'planning'], u'date_worked': u'2014-04-17', u'updated_at': None, u'user': u'userone', u'duration': 1200, u'deleted_at': None, u'uuid': u'c3706e79-1c9a-4765-8d7f-89b4544cad56', u'notes': u'Worked on documentation.', u'project': [u'ganeti-webmgr', u'gwm'], u'issue_uri': u'https://github.com/osuosl/ganeti_webmgr', u'created_at': u'2014-04-17', u'revision': 1}, {u'activities': [u'code', u'planning'], u'date_worked': u'2014-04-17', u'updated_at': None, u'user': u'usertwo', u'duration': 1300, u'deleted_at': None, u'uuid': u'12345676-1c9a-rrrr-bbbb-89b4544cad56', u'notes': u'Worked on coding', u'project': [u'ganeti-webmgr', u'gwm'], u'issue_uri': u'https://github.com/osuosl/ganeti_webmgr', u'created_at': u'2014-04-17', u'revision': 1}, {u'activities': [u'code'], u'date_worked': u'2014-04-17', u'updated_at': None, u'user': u'userthree', u'duration': 1400, u'deleted_at': None, u'uuid': u'12345676-1c9a-ssss-cccc-89b4544cad56', u'notes': u'Worked on coding', u'project': [u'timesync', u'ts'], u'issue_uri': u'https://github.com/osuosl/timesync', u'created_at': u'2014-04-17', u'revision': 1}]
       >>>
 
     .. warning::
 
       If the ``uuid`` parameter is passed all other parameters will be ignored
       except for ``include_deleted`` and ``include_revisions``. For example,
-      ``ts.get_times(uuid="time-entry-uuid", user=["bob"])`` is equivalent to
-      ``ts.get_times(uuid="time-entry-uuid")``.
+      ``ts.get_times({"uuid": "time-entry-uuid", "user": ["bob", "rob"]})`` is
+      equivalent to ``ts.get_times({"uuid": "time-entry-uuid"})``.
 
 ------------------------------------------
 
@@ -425,7 +427,7 @@ TimeSync.\ **delete_time(uuid)**
 
     ``uuid`` is a string containing the uuid of the time entry to be deleted.
 
-    **delete_time()** returns a ``[{"status": 200}]`` if successful or an error
+    **delete_time()** returns a ``{"status": 200}`` if successful or an error
     message if unsuccessful.
 
     Example usage:
@@ -433,7 +435,7 @@ TimeSync.\ **delete_time(uuid)**
     .. code-block:: python
 
       >>> ts.delete_time(uuid="some-uuid")
-      [{"status": 200}]
+      {"status": 200}
       >>>
 
 ------------------------------------------
@@ -473,7 +475,7 @@ TimeSync.\ **get_projects(query_parameters=None)**
     .. code-block:: python
 
       >>> ts.get_projects()
-      [{'users': {'tschuy': {'member': true, 'spectator': false, 'manager': false}, 'mrsj': {'member': true, 'spectator': false, 'manager': true}, 'oz': {'member': false, 'spectator': true, 'manager': false}}, 'uuid': 'a034806c-00db-4fe1-8de8-514575f31bfb', 'deleted_at': None, 'name': 'Ganeti Web Manager', 'updated_at': '2014-07-20', 'created_at': '2014-07-17', 'revision': 4, 'uri': 'https://code.osuosl.org/projects/ganeti-webmgr', 'slugs': ['gwm']}, {'users': {'managers': ['tschuy'], 'spectators': ['tschuy', 'mrsj'], 'members': ['patcht', 'tschuy', 'mrsj']}, 'uuid': 'a034806c-rrrr-bbbb-8de8-514575f31bfb', 'deleted_at': None, 'name': 'TimeSync', 'updated_at': '2014-07-20', 'created_at': '2014-07-17', 'revision': 2, 'uri': 'https://code.osuosl.org/projects/timesync', 'slugs': ['timesync', 'ts']}, {'users': {'managers': ['mrsj'], 'spectators': ['tschuy', 'mrsj'], 'members': ['patcht', 'tschuy', 'mrsj', 'MaraJade', 'thai']}, 'uuid': 'a034806c-ssss-cccc-8de8-514575f31bfb', 'deleted_at': None, 'name': 'pymesync', 'updated_at': '2014-07-20', 'created_at': '2014-07-17', 'revision': 1, 'uri': 'https://code.osuosl.org/projects/pymesync', 'slugs': ['pymesync', 'ps']}]
+      [{u'users': {u'tschuy': {u'member': true, u'spectator': false, u'manager': false}, u'mrsj': {u'member': true, u'spectator': false, u'manager': true}, u'oz': {u'member': false, u'spectator': true, u'manager': false}}, u'uuid': u'a034806c-00db-4fe1-8de8-514575f31bfb', u'deleted_at': None, u'name': u'Ganeti Web Manager', u'updated_at': u'2014-07-20', u'created_at': u'2014-07-17', u'revision': 4, u'uri': u'https://code.osuosl.org/projects/ganeti-webmgr', u'slugs': [u'gwm']}, {u'users': {u'managers': [u'tschuy'], u'spectators': [u'tschuy', u'mrsj'], u'members': [u'patcht', u'tschuy', u'mrsj']}, u'uuid': u'a034806c-rrrr-bbbb-8de8-514575f31bfb', u'deleted_at': None, u'name': u'TimeSync', u'updated_at': u'2014-07-20', u'created_at': u'2014-07-17', u'revision': 2, u'uri': u'https://code.osuosl.org/projects/timesync', u'slugs': [u'timesync', u'ts']}, {u'users': {u'managers': [u'mrsj'], u'spectators': [u'tschuy', u'mrsj'], u'members': [u'patcht', u'tschuy', u'mrsj', u'MaraJade', u'thai']}, u'uuid': u'a034806c-ssss-cccc-8de8-514575f31bfb', u'deleted_at': None, u'name': u'pymesync', u'updated_at': u'2014-07-20', u'created_at': u'2014-07-17', u'revision': 1, u'uri': u'https://code.osuosl.org/projects/pymesync', u'slugs': [u'pymesync', u'ps']}]
       >>>
 
     .. warning::
@@ -518,7 +520,7 @@ TimeSync.\ **get_activities(query_parameters=None)**
     .. code-block:: python
 
       >>> ts.get_activities()
-      [{'uuid': 'adf036f5-3d49-4a84-bef9-062b46380bbf', 'created_at': '2014-04-17', 'updated_at': None, 'name': 'Documentation', 'deleted_at': None, 'slugs': ['docs'], 'revision': 5}, {'uuid': 'adf036f5-3d49-bbbb-rrrr-062b46380bbf', 'created_at': '2014-04-17', 'updated_at': None, 'name': 'Coding', 'deleted_at': None, 'slugs': ['code', 'dev'], 'revision': 1}, {'uuid': 'adf036f5-3d49-cccc-ssss-062b46380bbf', 'created_at': '2014-04-17', 'updated_at': None, 'name': 'Planning', 'deleted_at': None, 'slugs': ['plan', 'prep'], 'revision': 1}]
+      [{u'uuid': u'adf036f5-3d49-4a84-bef9-062b46380bbf', u'created_at': u'2014-04-17', u'updated_at': None, u'name': u'Documentation', u'deleted_at': None, u'slugs': [u'docs'], u'revision': 5}, {u'uuid': u'adf036f5-3d49-bbbb-rrrr-062b46380bbf', u'created_at': u'2014-04-17', u'updated_at': None, u'name': u'Coding', u'deleted_at': None, u'slugs': [u'code', u'dev'], u'revision': 1}, {u'uuid': u'adf036f5-3d49-cccc-ssss-062b46380bbf', u'created_at': u'2014-04-17', u'updated_at': None, u'name': u'Planning', u'deleted_at': None, u'slugs': [u'plan', u'prep'], u'revision': 1}]
       >>>
 
     .. warning::
@@ -544,7 +546,7 @@ TimeSync.\ **get_users(username=None)**
     .. code-block:: python
 
       >>> ts.get_users()
-      [{'username': 'userone', 'displayname': 'One Is The Loneliest Number', 'admin': False, 'created_at': '2015-02-29', 'active': True, 'deleted_at': None, 'email': 'exampleone@example.com'}, {'username': 'usertwo', 'displayname': 'Two Can Be As Bad As One', 'admin': False, 'created_at': '2015-02-29', 'active': True, 'deleted_at': None, 'email': 'exampletwo@example.com'}, {'username': 'userthree', 'displayname': "Yes It's The Saddest Experience", 'admin': False, 'created_at': '2015-02-29', 'active': True, 'deleted_at': None, 'email': 'examplethree@example.com'}, {'username': 'userfour', 'displayname': "You'll Ever Do", 'admin': False, 'created_at': '2015-02-29', 'active': True, 'deleted_at': None, 'email': 'examplefour@example.com'}]
+      [{u'username': u'userone', u'displayname': u'One Is The Loneliest Number', u'admin': False, u'created_at': u'2015-02-29', u'active': True, u'deleted_at': None, u'email': u'exampleone@example.com'}, {u'username': u'usertwo', u'displayname': u'Two Can Be As Bad As One', u'admin': False, u'created_at': u'2015-02-29', u'active': True, u'deleted_at': None, u'email': u'exampletwo@example.com'}, {u'username': u'userthree', u'displayname': "Yes It's The Saddest Experience", u'admin': False, u'created_at': u'2015-02-29', u'active': True, u'deleted_at': None, u'email': u'examplethree@example.com'}, {u'username': u'userfour', u'displayname': "You'll Ever Do", u'admin': False, u'created_at': u'2015-02-29', u'active': True, u'deleted_at': None, u'email': u'examplefour@example.com'}]
       >>>
 
 ------------------------------------------
@@ -559,10 +561,9 @@ These methods are available to TimeSync users with administrative permissions.
 TimeSync.\ **create_project(project)**
 
     Create a project on the TimeSync instance at the baseurl provided when
-    instantiating the TimeSync object. This method will return a list with
-    a single python dictionary containing the created project if successful. The
-    dictionary will contain error information if ``create_project()`` was
-    unsuccessful.
+    instantiating the TimeSync object. This method will return a single python
+    dictionary containing the created project if successful. The dictionary
+    will contain error information if ``create_project()`` was unsuccessful.
 
     ``project`` is a python dictionary containing the project information to
     send to TimeSync. The syntax is ``"key": "value"`` except for the
@@ -594,7 +595,7 @@ TimeSync.\ **create_project(project)**
       ...}
       >>>
       >>> ts.create_project(project=project)
-      [{'users': {'tschuy': {'member': true, 'spectator': false, 'manager': true}, 'mrsj': {'member': true, 'spectator': false, 'manager': false}, 'patcht': {'member': true, 'spectator': false, 'manager': true}, 'oz': {'member': false, 'spectator': true, 'manager': false}}, 'deleted_at': None, 'uuid': '309eae69-21dc-4538-9fdc-e6892a9c4dd4', 'updated_at': None, 'created_at': '2015-05-23', 'uri': 'https://code.osuosl.org/projects/timesync', 'name': 'TimeSync API', 'revision': 1, 'slugs': ['timesync', 'time'], 'users': {'managers': ['tschuy'], 'spectators': ['tschuy'], 'members': ['patcht', 'tschuy']}}]
+      {u'users': {u'tschuy': {u'member': true, u'spectator': false, u'manager': true}, u'mrsj': {u'member': true, u'spectator': false, u'manager': false}, u'patcht': {u'member': true, u'spectator': false, u'manager': true}, u'oz': {u'member': false, u'spectator': true, u'manager': false}}, u'deleted_at': None, u'uuid': u'309eae69-21dc-4538-9fdc-e6892a9c4dd4', u'updated_at': None, u'created_at': u'2015-05-23', u'uri': u'https://code.osuosl.org/projects/timesync', u'name': u'TimeSync API', u'revision': 1, u'slugs': [u'timesync', u'time'], u'users': {u'managers': [u'tschuy'], u'spectators': [u'tschuy'], u'members': [u'patcht', u'tschuy']}}
       >>>
 
 ------------------------------------------
@@ -603,9 +604,9 @@ TimeSync.\ **update_project(project, slug)**
 
     Update an existing project by slug on the TimeSync instance specified by the
     baseurl provided when instantiating the TimeSync object. This method will
-    return a list with a single python dictionary containing the updated project
-    if successful. The dictionary will contain error information if
-    ``update_project()`` was unsuccessful.
+    return a python dictionary containing the updated project if successful.
+    The dictionary will contain error information if ``update_project()`` was
+    unsuccessful.
 
     ``project`` is a python dictionary containing the project information to
     send to TimeSync. The syntax is ``"key": "value"`` except for the
@@ -635,7 +636,7 @@ TimeSync.\ **update_project(project, slug)**
       ...    "name": "pymesync",
       ...}
       >>> ts.update_project(project=project, slug="ps")
-      [{'users': {'tschuy': {'member': true, 'spectator': true, 'manager': true}, 'patcht': {'member': true, 'spectator': false, 'manager': false}}, 'uuid': '309eae69-21dc-4538-9fdc-e6892a9c4dd4', 'name': 'pymesync', 'updated_at': '2014-04-18', 'created_at': '2014-04-16', 'deleted_at': None, 'revision': 2, 'uri': 'https://code.osuosl.org/projects/timesync', 'slugs': ['ps']}]
+      {u'users': {u'tschuy': {u'member': True, u'spectator': True, u'manager': True}, u'patcht': {u'member': True, u'spectator': False, u'manager': False}}, u'uuid': u'309eae69-21dc-4538-9fdc-e6892a9c4dd4', u'name': u'pymesync', u'updated_at': u'2014-04-18', u'created_at': u'2014-04-16', u'deleted_at': None, u'revision': 2, u'uri': u'https://code.osuosl.org/projects/timesync', u'slugs': [u'ps']}]
       >>>
 
 ------------------------------------------
@@ -647,7 +648,7 @@ TimeSync.\ **delete_project(slug)**
 
     ``slug`` is a string containing the slug of the project to be deleted.
 
-    **delete_project()** returns a ``[{"status": 200}]`` if successful or an
+    **delete_project()** returns a ``{"status": 200}`` if successful or an
     error message if unsuccessful.
 
     Example usage:
@@ -655,7 +656,7 @@ TimeSync.\ **delete_project(slug)**
     .. code-block:: python
 
       >>> ts.delete_project(slug="some-slug")
-      [{"status": 200}]
+      {u'status': 200}]
       >>>
 
 ------------------------------------------
@@ -663,10 +664,9 @@ TimeSync.\ **delete_project(slug)**
 TimeSync.\ **create_activity(activity)**
 
     Create an activity on the TimeSync instance at the baseurl provided when
-    instantiating the TimeSync object. This method will return a list with
-    a single python dictionary containing the created activity if successful.
-    The dictionary will contain error information if ``create_activity()`` was
-    unsuccessful.
+    instantiating the TimeSync object. This method will return a python
+    dictionary containing the created activity if successful. The dictionary
+    will contain error information if ``create_activity()`` was unsuccessful.
 
     ``activity`` is a python dictionary containing the activity information to
     send to TimeSync. The syntax is ``"key": "value"``. ``activity`` requires
@@ -684,7 +684,7 @@ TimeSync.\ **create_activity(activity)**
       ...    "slug": "qa"
       ...}
       >>> ts.create_activity(activity=activity)
-      [{'uuid': 'cfa07a4f-d446-4078-8d73-2f77560c35c0', 'created_at': '2013-07-27', 'updated_at': None, 'deleted_at': None, 'revision': 1, 'slug': 'qa', 'name': 'Quality Assurance/Testing'}]
+      {u'uuid': u'cfa07a4f-d446-4078-8d73-2f77560c35c0', u'created_at': u'2013-07-27', u'updated_at': None, u'deleted_at': None, u'revision': 1, u'slug': u'qa', u'name': u'Quality Assurance/Testing'}
       >>>
 
 ------------------------------------------
@@ -693,8 +693,8 @@ TimeSync.\ **update_activity(activity, slug)**
 
     Update an existing activity by slug on the TimeSync instance specified by
     the baseurl provided when instantiating the TimeSync object. This method
-    will return a list with a single python dictionary containing the updated
-    activity if successful. The dictionary will contain error information if
+    will return a python dictionary containing the updated activity if
+    successful. The dictionary will contain error information if
     ``update_activity()`` was unsuccessful.
 
     ``activity`` is a python dictionary containing the activity information to
@@ -718,7 +718,7 @@ TimeSync.\ **update_activity(activity, slug)**
 
       >>> activity = {"name": "Code in the wild"}
       >>> ts.update_activity(activity=activity, slug="ciw")
-      [{'uuid': '3cf78d25-411c-4d1f-80c8-a09e5e12cae3', 'created_at': '2014-04-16', 'updated_at': '2014-04-17', 'deleted_at': None, 'revision': 2, 'slug': 'ciw', 'name': 'Code in the wild'}]
+      {u'uuid': u'3cf78d25-411c-4d1f-80c8-a09e5e12cae3', u'created_at': u'2014-04-16', u'updated_at': u'2014-04-17', u'deleted_at': None, u'revision': 2, u'slug': u'ciw', u'name': u'Code in the wild'}
       >>>
 
 ------------------------------------------
@@ -730,7 +730,7 @@ TimeSync.\ **delete_activity(slug)**
 
     ``slug`` is a string containing the slug of the activity to be deleted.
 
-    **delete_activity()** returns a ``[{"status": 200}]`` if successful or an
+    **delete_activity()** returns a ``{"status": 200}`` if successful or an
     error message if unsuccessful.
 
     Example usage:
@@ -738,7 +738,7 @@ TimeSync.\ **delete_activity(slug)**
     .. code-block:: python
 
       >>> ts.delete_activity(slug="some-slug")
-      [{"status": 200}]
+      {u'status': 200}
       >>>
 
 
@@ -747,10 +747,9 @@ TimeSync.\ **delete_activity(slug)**
 TimeSync.\ **create_user(user)**
 
     Create a user on the TimeSync instance at the baseurl provided when
-    instantiating the TimeSync object. This method will return a list with
-    a single python dictionary containing the created user if successful.
-    The dictionary will contain error information if ``create_user()`` was
-    unsuccessful.
+    instantiating the TimeSync object. This method will return a python
+    dictionary containing the created user if successful. The dictionary will
+    contain error information if ``create_user()`` was unsuccessful.
 
     ``user`` is a python dictionary containing the user information to send to
     TimeSync. The syntax is ``"key": "value"``. ``user`` requires the following
@@ -779,7 +778,7 @@ TimeSync.\ **create_user(user)**
       ...    "email": "example@example.com"
       ...}
       >>> ts.create_user(user=user)
-      [{'username': 'example', 'deleted_at': None, 'displayname': 'X. Ample User', 'admin': False, 'created_at': '2015-05-23', 'active': True, 'email': 'example@example.com'}]
+      {u'username': u'example', u'deleted_at': None, u'displayname': u'X. Ample User', u'admin': False, u'created_at': u'2015-05-23', u'active': True, u'email': u'example@example.com'}
       >>>
 
 ------------------------------------------
@@ -788,9 +787,9 @@ TimeSync.\ **update_user(user, username)**
 
     Update an existing user by ``username`` on the TimeSync instance specified
     by the baseurl provided when instantiating the TimeSync object. This method
-    will return a list with a single python dictionary containing the updated
-    user if successful. The dictionary will contain error information if
-    ``update_user()`` was unsuccessful.
+    will return a python dictionary containing the updated user if successful.
+    The dictionary will contain error information if ``update_user()`` was
+    unsuccessful.
 
     ``user`` is a python dictionary containing the user information to send to
     TimeSync. The syntax is ``"key": "value"``.
@@ -815,7 +814,7 @@ TimeSync.\ **update_user(user, username)**
       ...    "email": "red-leader@yavin.com"
       ...}
       >>> ts.update_user(user=user, username="example")
-      [{'username': 'red-leader', 'displayname': 'Mr. Example', 'admin': False, 'created_at': '2015-02-29', 'active': True, 'deleted_at': None, 'email': 'red-leader@yavin.com'}]
+      {u'username': u'red-leader', u'displayname': u'Mr. Example', u'admin': False, u'created_at': u'2015-02-29', u'active': True, u'deleted_at': None, u'email': u'red-leader@yavin.com'}
       >>>
 
 ------------------------------------------
@@ -827,7 +826,7 @@ TimeSync.\ **delete_user(username)**
 
     ``username`` is a string containing the username of the user to be deleted.
 
-    **delete_user()** returns a ``[{"status": 200}]`` if successful or an error
+    **delete_user()** returns a ``{"status": 200}`` if successful or an error
     message if unsuccessful.
 
     Example usage:
@@ -835,5 +834,5 @@ TimeSync.\ **delete_user(username)**
     .. code-block:: python
 
       >>> ts.delete_user(username="username")
-      [{"status": 200}]
+      {u'status": 200}
       >>>

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -546,7 +546,7 @@ TimeSync.\ **get_users(username=None)**
     .. code-block:: python
 
       >>> ts.get_users()
-      [{u'username': u'userone', u'displayname': u'One Is The Loneliest Number', u'admin': False, u'created_at': u'2015-02-29', u'active': True, u'deleted_at': None, u'email': u'exampleone@example.com'}, {u'username': u'usertwo', u'displayname': u'Two Can Be As Bad As One', u'admin': False, u'created_at': u'2015-02-29', u'active': True, u'deleted_at': None, u'email': u'exampletwo@example.com'}, {u'username': u'userthree', u'displayname': "Yes It's The Saddest Experience", u'admin': False, u'created_at': u'2015-02-29', u'active': True, u'deleted_at': None, u'email': u'examplethree@example.com'}, {u'username': u'userfour', u'displayname': "You'll Ever Do", u'admin': False, u'created_at': u'2015-02-29', u'active': True, u'deleted_at': None, u'email': u'examplefour@example.com'}]
+      [{u'username': u'userone', u'displayname': u'One Is The Loneliest Number', u'admin': False, u'created_at': u'2015-02-29', u'active': True, u'deleted_at': None, u'email': u'exampleone@example.com'}, {u'username': u'usertwo', u'displayname': u'Two Can Be As Bad As One', u'admin': False, u'created_at': u'2015-02-29', u'active': True, u'deleted_at': None, u'email': u'exampletwo@example.com'}, {u'username': u'userthree', u'displayname': u'Yes Its The Saddest Experience', u'admin': False, u'created_at': u'2015-02-29', u'active': True, u'deleted_at': None, u'email': u'examplethree@example.com'}, {u'username': u'userfour', u'displayname': u'Youll Ever Do', u'admin': False, u'created_at': u'2015-02-29', u'active': True, u'deleted_at': None, u'email': u'examplefour@example.com'}]
       >>>
 
 ------------------------------------------
@@ -595,7 +595,7 @@ TimeSync.\ **create_project(project)**
       ...}
       >>>
       >>> ts.create_project(project=project)
-      {u'users': {u'tschuy': {u'member': true, u'spectator': false, u'manager': true}, u'mrsj': {u'member': true, u'spectator': false, u'manager': false}, u'patcht': {u'member': true, u'spectator': false, u'manager': true}, u'oz': {u'member': false, u'spectator': true, u'manager': false}}, u'deleted_at': None, u'uuid': u'309eae69-21dc-4538-9fdc-e6892a9c4dd4', u'updated_at': None, u'created_at': u'2015-05-23', u'uri': u'https://code.osuosl.org/projects/timesync', u'name': u'TimeSync API', u'revision': 1, u'slugs': [u'timesync', u'time'], u'users': {u'managers': [u'tschuy'], u'spectators': [u'tschuy'], u'members': [u'patcht', u'tschuy']}}
+      {u'users': {u'tschuy': {u'member': true, u'spectator': false, u'manager': true}, u'mrsj': {u'member': true, u'spectator': false, u'manager': false}, u'patcht': {u'member': true, u'spectator': false, u'manager': true}, u'oz': {u'member': false, u'spectator': true, u'manager': false}}, u'deleted_at': None, u'uuid': u'309eae69-21dc-4538-9fdc-e6892a9c4dd4', u'updated_at': None, u'created_at': u'2015-05-23', u'uri': u'https://code.osuosl.org/projects/timesync', u'name': u'TimeSync API', u'revision': 1, u'slugs': [u'timesync', u'time']}
       >>>
 
 ------------------------------------------
@@ -656,7 +656,7 @@ TimeSync.\ **delete_project(slug)**
     .. code-block:: python
 
       >>> ts.delete_project(slug="some-slug")
-      {u'status': 200}]
+      {u'status': 200}
       >>>
 
 ------------------------------------------

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -129,19 +129,28 @@ of code.
 Errors
 ------
 
-Pymesync returns errors the same way it returns all other information: as a
-Python dictionary inside a list. If the error is a local pymesync error, the
+Pymesync returns errors the same way it returns successes for whatever method is
+in use. This means that most of the time errors are returned as a Python
+dictionary inside a list. If the error is a local pymesync error, the
 key for the error message will be ``"pymesync error"``. If the error is from
 TimeSync, the dictionary will contain the same keys described in the
 `TimeSync error documentation`_, but as a python dictionary.
 
 If there is an error connecting with the TimeSync instance specified by the
 baseurl passed to the pymesync constructor, the error will also contain the
-status code of the response. For example:
+status code of the response.
+
+An example for a method that returns a dict within a list:
 
 .. code-block:: python
 
     [{"pymesync error": "connection to TimeSync failed at baseurl http://ts.example.com/v1 - response status was 502"}]
+
+The same error returned from a method that returns a single dict:
+
+.. code-block:: python
+
+    {"pymesync error": "connection to TimeSync failed at baseurl http://ts.example.com/v1 - response status was 502"}
 
 .. _TimeSync error documentation: http://timesync.readthedocs.org/en/latest/draft_errors.html
 

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -636,7 +636,7 @@ TimeSync.\ **update_project(project, slug)**
       ...    "name": "pymesync",
       ...}
       >>> ts.update_project(project=project, slug="ps")
-      {u'users': {u'tschuy': {u'member': True, u'spectator': True, u'manager': True}, u'patcht': {u'member': True, u'spectator': False, u'manager': False}}, u'uuid': u'309eae69-21dc-4538-9fdc-e6892a9c4dd4', u'name': u'pymesync', u'updated_at': u'2014-04-18', u'created_at': u'2014-04-16', u'deleted_at': None, u'revision': 2, u'uri': u'https://code.osuosl.org/projects/timesync', u'slugs': [u'ps']}]
+      {u'users': {u'tschuy': {u'member': True, u'spectator': True, u'manager': True}, u'patcht': {u'member': True, u'spectator': False, u'manager': False}}, u'uuid': u'309eae69-21dc-4538-9fdc-e6892a9c4dd4', u'name': u'pymesync', u'updated_at': u'2014-04-18', u'created_at': u'2014-04-16', u'deleted_at': None, u'revision': 2, u'uri': u'https://code.osuosl.org/projects/timesync', u'slugs': [u'ps']}
       >>>
 
 ------------------------------------------

--- a/pymesync/mock_pymesync.py
+++ b/pymesync/mock_pymesync.py
@@ -1,7 +1,7 @@
 import datetime
 
 def authenticate():
-    return [{"token": "TESTTOKEN"}]
+    return {"token": "TESTTOKEN"}
 
 
 def token_expiration_time():
@@ -17,7 +17,7 @@ def create_time(p_dict):
     p_dict["revision"] = 1
     p_dict["notes"] = p_dict["notes"] if p_dict["notes"] else None
     p_dict["issue_uri"] = p_dict["issue_uri"] if p_dict["issue_uri"] else None
-    return [p_dict]
+    return p_dict
 
 
 def update_time(p_dict, uuid):
@@ -39,7 +39,7 @@ def update_time(p_dict, uuid):
         "uuid": uuid,
         "revision": 2
     }
-    return [updated_param]
+    return updated_param
 
 
 def create_project(p_dict):
@@ -54,7 +54,7 @@ def create_project(p_dict):
     p_dict["updated_at"] = None
     p_dict["deleted_at"] = None
     p_dict["uri"] = p_dict["uri"] if "uri" in p_dict else None
-    return [p_dict]
+    return p_dict
 
 
 def update_project(p_dict, slug):
@@ -81,7 +81,7 @@ def update_project(p_dict, slug):
             ]
         }
     }
-    return [updated_param]
+    return updated_param
 
 
 def create_activity(p_dict):
@@ -91,7 +91,7 @@ def create_activity(p_dict):
     p_dict["updated_at"] = None
     p_dict["deleted_at"] = None
     p_dict["revision"] = 1
-    return [p_dict]
+    return p_dict
 
 
 def update_activity(p_dict, slug):
@@ -105,7 +105,7 @@ def update_activity(p_dict, slug):
         "deleted_at": None,
         "revision": 2
     }
-    return [updated_param]
+    return updated_param
 
 
 def create_user(p_dict):
@@ -115,7 +115,7 @@ def create_user(p_dict):
     p_dict["created_at"] = "2015-05-23"
     p_dict["deleted_at"] = None
     del(p_dict["password"])
-    return [p_dict]
+    return p_dict
 
 
 def update_user(p_dict, username):
@@ -131,7 +131,7 @@ def update_user(p_dict, username):
         "created_at": "2015-02-29",
         "deleted_at": None
     }
-    return [updated_param]
+    return updated_param
 
 
 def get_times(uuid):

--- a/pymesync/pymesync.py
+++ b/pymesync/pymesync.py
@@ -120,10 +120,10 @@ class TimeSync(object):
         # If TimeSync returns an error, return the error without setting the
         # token.
         # Else set the token to the returned token and return the dict.
-        if "error" in token_list_dict[0] or "token" not in token_list_dict[0]:
+        if "error" in token_list_dict or "token" not in token_list_dict:
             return token_list_dict
         else:
-            self.token = token_list_dict[0]["token"]
+            self.token = token_list_dict["token"]
             return token_list_dict
 
     def create_time(self, time):
@@ -149,7 +149,7 @@ class TimeSync(object):
             if not isinstance(time['duration'], int):
                 return duration
 
-        return self.__create_or_update(time, None, "time", "times")
+        return [self.__create_or_update(time, None, "time", "times")]
 
     def update_time(self, time, uuid):
         """
@@ -176,7 +176,7 @@ class TimeSync(object):
             if not isinstance(time['duration'], int):
                 return duration
 
-        return self.__create_or_update(time, uuid, "time", "times", False)
+        return [self.__create_or_update(time, uuid, "time", "times", False)]
 
     def create_project(self, project):
         """
@@ -190,7 +190,7 @@ class TimeSync(object):
         ``project`` is a python dictionary containing the project information
         to send to TimeSync.
         """
-        return self.__create_or_update(project, None, "project", "projects")
+        return [self.__create_or_update(project, None, "project", "projects")]
 
     def update_project(self, project, slug):
         """
@@ -206,8 +206,8 @@ class TimeSync(object):
         to send to TimeSync.
         ``slug`` contains the slug for a project entry to update.
         """
-        return self.__create_or_update(project, slug, "project", "projects",
-                                       False)
+        return [self.__create_or_update(project, slug, "project", "projects",
+                                       False)]
 
     def create_activity(self, activity):
         """
@@ -221,8 +221,8 @@ class TimeSync(object):
         ``activity`` is a python dictionary containing the activity information
         to send to TimeSync.
         """
-        return self.__create_or_update(activity, None,
-                                       "activity", "activities")
+        return [self.__create_or_update(activity, None,
+                                       "activity", "activities")]
 
     def update_activity(self, activity, slug):
         """
@@ -238,9 +238,9 @@ class TimeSync(object):
         to send to TimeSync.
         ``slug`` contains the slug for an activity entry to update.
         """
-        return self.__create_or_update(activity, slug,
+        return [self.__create_or_update(activity, slug,
                                        "activity", "activities",
-                                       False)
+                                       False)]
 
     def create_user(self, user):
         """
@@ -259,7 +259,7 @@ class TimeSync(object):
                 return [{self.error: "user object: "
                          "{} must be True or False".format(perm)}]
 
-        return self.__create_or_update(user, None, "user", "users")
+        return [self.__create_or_update(user, None, "user", "users")]
 
     def update_user(self, user, username):
         """
@@ -275,7 +275,7 @@ class TimeSync(object):
         to TimeSync.
         ``username`` contains the username for a user to update.
         """
-        return self.__create_or_update(user, username, "user", "users", False)
+        return [self.__create_or_update(user, username, "user", "users", False)]
 
     def get_times(self, query_parameters=None):
         """
@@ -522,10 +522,10 @@ class TimeSync(object):
         # Check that user has authenticated
         local_auth_error = self.__local_auth_error()
         if local_auth_error:
-            return [{self.error: local_auth_error}]
+            return {self.error: local_auth_error}
 
         if not uuid:
-            return [{self.error: "missing uuid; please add to method call"}]
+            return {self.error: "missing uuid; please add to method call"}
 
         return self.__delete_object("times", uuid)
 
@@ -541,10 +541,10 @@ class TimeSync(object):
         # Check that user has authenticated
         local_auth_error = self.__local_auth_error()
         if local_auth_error:
-            return [{self.error: local_auth_error}]
+            return {self.error: local_auth_error}
 
         if not slug:
-            return [{self.error: "missing slug; please add to method call"}]
+            return {self.error: "missing slug; please add to method call"}
 
         return self.__delete_object("projects", slug)
 
@@ -560,10 +560,10 @@ class TimeSync(object):
         # Check that user has authenticated
         local_auth_error = self.__local_auth_error()
         if local_auth_error:
-            return [{self.error: local_auth_error}]
+            return {self.error: local_auth_error}
 
         if not slug:
-            return [{self.error: "missing slug; please add to method call"}]
+            return {self.error: "missing slug; please add to method call"}
 
         return self.__delete_object("activities", slug)
 
@@ -580,11 +580,11 @@ class TimeSync(object):
         # Check that user has authenticated
         local_auth_error = self.__local_auth_error()
         if local_auth_error:
-            return [{self.error: local_auth_error}]
+            return {self.error: local_auth_error}
 
         if not username:
-            return [{self.error:
-                     "missing username; please add to method call"}]
+            return {self.error:
+                    "missing username; please add to method call"}
 
         return self.__delete_object("users", username)
 
@@ -598,7 +598,7 @@ class TimeSync(object):
         # Check that user has authenticated
         local_auth_error = self.__local_auth_error()
         if local_auth_error:
-            return [{self.error: local_auth_error}]
+            return {self.error: local_auth_error}
 
         # Return valid date if in test mode
         if self.test:
@@ -609,7 +609,7 @@ class TimeSync(object):
         try:
             decoded_payload = base64.b64decode(self.token.split(".", 1)[1])
         except:
-            return [{self.error: "improperly encoded token"}]
+            return {self.error: "improperly encoded token"}
 
         # literal_eval the string representation of a dict to convert it to a
         # dict, then get the value at 'exp'. The value at 'exp' is epoch time
@@ -634,12 +634,12 @@ class TimeSync(object):
         # Check that user has authenticated
         local_auth_error = self.__local_auth_error()
         if local_auth_error:
-            return [{self.error: local_auth_error}]
+            return {self.error: local_auth_error}
 
         # Check that a project slug was passed
         if not project:
-            return [{self.error: "Missing project slug, please "
-                                 "include in method call"}]
+            return {self.error: "Missing project slug, please "
+                                "include in method call"}
 
         # Construct query url
         url = "{0}/projects/{1}?token={2}".format(self.baseurl,
@@ -656,15 +656,15 @@ class TimeSync(object):
             project_object = self.__response_to_python(response)
         except requests.exceptions.RequestException as e:
             # Request Error
-            return [{self.error: e}]
+            return {self.error: e}
 
         # Create the user dict to return
         # There was an error, don't do anything with it, return as a list
-        if "error" in project_object[0]:
-            return [project_object[0]]
+        if "error" in project_object:
+            return project_object
 
         # Get the user object from the project
-        users = project_object[0]["users"]
+        users = project_object["users"]
 
         # Convert the nested permissions dict to a list containing only
         # relevant (true) permissions
@@ -702,7 +702,7 @@ class TimeSync(object):
         """Convert response to native python list of objects"""
         # DELETE returns an empty body if successful
         if not response.text and response.status_code == 200:
-            return [{"status": 200}]
+            return {"status": 200}
 
         # If response.text is valid JSON, it came from TimeSync. If it isn't
         # and we got a ValueError, we know we are having trouble connecting to
@@ -715,11 +715,7 @@ class TimeSync(object):
             err_msg = "connection to TimeSync failed at baseurl {} - ".format(
                 self.baseurl)
             err_msg += "response status was {}".format(response.status_code)
-            return [{self.error: err_msg}]
-
-        # Pymesync returns responses as a python dictionary contained in a list
-        if not isinstance(python_object, list):
-            python_object = [python_object]
+            return {self.error: err_msg}
 
         return python_object
 
@@ -845,14 +841,14 @@ class TimeSync(object):
         # Check that user has authenticated
         local_auth_error = self.__local_auth_error()
         if local_auth_error:
-            return [{self.error: local_auth_error}]
+            return {self.error: local_auth_error}
 
         # Check that object contains required fields and no bad fields
         field_error = self.__get_field_errors(object_fields,
                                               object_name,
                                               create_object)
         if field_error:
-            return [{self.error: field_error}]
+            return {self.error: field_error}
 
         # Since this is a POST request, we need an auth and object objects
         values = {"auth": self.__token_auth(), "object": object_fields}
@@ -878,7 +874,7 @@ class TimeSync(object):
             return self.__response_to_python(response)
         except requests.exceptions.RequestException as e:
             # Request error
-            return [{self.error: e}]
+            return {self.error: e}
 
     def __duration_to_seconds(self, duration):
         """When a time_entry is created, a user will enter a time duration as
@@ -916,7 +912,7 @@ class TimeSync(object):
             return self.__response_to_python(response)
         except requests.exceptions.RequestException as e:
             # Request error
-            return [{self.error: e}]
+            return {self.error: e}
 
     def __test_handler(self, parameters, identifier, obj_name, create_object):
         """Handle test methods in test mode for creating or updating an

--- a/pymesync/pymesync.py
+++ b/pymesync/pymesync.py
@@ -86,10 +86,9 @@ class TimeSync(object):
             arg_error_list.append("auth_type")
 
         if arg_error_list:
-            return [
-                {self.error: "Missing {}; please add to method call".format(
-                    ", ".join(arg_error_list))}
-            ]
+            return {self.error: "Missing {}; "
+                                "please add to method call".format(
+                                    ", ".join(arg_error_list))}
 
         del(arg_error_list)
 
@@ -112,19 +111,19 @@ class TimeSync(object):
         try:
             # Success!
             response = requests.post(url, json=auth)
-            token_list_dict = self.__response_to_python(response)
+            token_response = self.__response_to_python(response)
         except requests.exceptions.RequestException as e:
             # Request error
-            return [{self.error: e}]
+            return {self.error: e}
 
         # If TimeSync returns an error, return the error without setting the
         # token.
         # Else set the token to the returned token and return the dict.
-        if "error" in token_list_dict or "token" not in token_list_dict:
-            return token_list_dict
+        if "error" in token_response or "token" not in token_response:
+            return token_response
         else:
-            self.token = token_list_dict["token"]
-            return token_list_dict
+            self.token = token_response["token"]
+            return token_response
 
     def create_time(self, time):
         """
@@ -139,7 +138,7 @@ class TimeSync(object):
         to TimeSync.
         """
         if time['duration'] < 0:
-            return [{self.error: "time object: duration cannot be negative"}]
+            return {self.error: "time object: duration cannot be negative"}
 
         if not isinstance(time['duration'], int):
             duration = self.__duration_to_seconds(time['duration'])
@@ -149,7 +148,7 @@ class TimeSync(object):
             if not isinstance(time['duration'], int):
                 return duration
 
-        return [self.__create_or_update(time, None, "time", "times")]
+        return self.__create_or_update(time, None, "time", "times")
 
     def update_time(self, time, uuid):
         """
@@ -166,7 +165,7 @@ class TimeSync(object):
         ``uuid`` contains the uuid for a time entry to update.
         """
         if time['duration'] < 0:
-            return [{self.error: "time object: duration cannot be negative"}]
+            return {self.error: "time object: duration cannot be negative"}
 
         if not isinstance(time['duration'], int):
             duration = self.__duration_to_seconds(time['duration'])
@@ -176,7 +175,7 @@ class TimeSync(object):
             if not isinstance(time['duration'], int):
                 return duration
 
-        return [self.__create_or_update(time, uuid, "time", "times", False)]
+        return self.__create_or_update(time, uuid, "time", "times", False)
 
     def create_project(self, project):
         """
@@ -190,7 +189,7 @@ class TimeSync(object):
         ``project`` is a python dictionary containing the project information
         to send to TimeSync.
         """
-        return [self.__create_or_update(project, None, "project", "projects")]
+        return self.__create_or_update(project, None, "project", "projects")
 
     def update_project(self, project, slug):
         """
@@ -206,8 +205,8 @@ class TimeSync(object):
         to send to TimeSync.
         ``slug`` contains the slug for a project entry to update.
         """
-        return [self.__create_or_update(project, slug, "project", "projects",
-                                       False)]
+        return self.__create_or_update(project, slug, "project", "projects",
+                                       False)
 
     def create_activity(self, activity):
         """
@@ -221,8 +220,8 @@ class TimeSync(object):
         ``activity`` is a python dictionary containing the activity information
         to send to TimeSync.
         """
-        return [self.__create_or_update(activity, None,
-                                       "activity", "activities")]
+        return self.__create_or_update(activity, None,
+                                       "activity", "activities")
 
     def update_activity(self, activity, slug):
         """
@@ -238,9 +237,9 @@ class TimeSync(object):
         to send to TimeSync.
         ``slug`` contains the slug for an activity entry to update.
         """
-        return [self.__create_or_update(activity, slug,
+        return self.__create_or_update(activity, slug,
                                        "activity", "activities",
-                                       False)]
+                                       False)
 
     def create_user(self, user):
         """
@@ -256,10 +255,10 @@ class TimeSync(object):
         """
         for perm in ["admin", "manager", "spectator", "active"]:
             if perm in user and not isinstance(user[perm], bool):
-                return [{self.error: "user object: "
-                         "{} must be True or False".format(perm)}]
+                return {self.error: "user object: "
+                        "{} must be True or False".format(perm)}
 
-        return [self.__create_or_update(user, None, "user", "users")]
+        return self.__create_or_update(user, None, "user", "users")
 
     def update_user(self, user, username):
         """
@@ -275,7 +274,7 @@ class TimeSync(object):
         to TimeSync.
         ``username`` contains the username for a user to update.
         """
-        return [self.__create_or_update(user, username, "user", "users", False)]
+        return self.__create_or_update(user, username, "user", "users", False)
 
     def get_times(self, query_parameters=None):
         """
@@ -330,7 +329,7 @@ class TimeSync(object):
         try:
             # Success!
             response = requests.get(url)
-            return self.__response_to_python(response)
+            return [self.__response_to_python(response)]
         except requests.exceptions.RequestException as e:
             # Request Error
             return [{self.error: e}]
@@ -398,7 +397,7 @@ class TimeSync(object):
         try:
             # Success!
             response = requests.get(url)
-            return self.__response_to_python(response)
+            return [self.__response_to_python(response)]
         except requests.exceptions.RequestException as e:
             # Request Error
             return [{self.error: e}]
@@ -466,7 +465,7 @@ class TimeSync(object):
         try:
             # Success!
             response = requests.get(url)
-            return self.__response_to_python(response)
+            return [self.__response_to_python(response)]
         except requests.exceptions.RequestException as e:
             # Request Error
             return [{self.error: e}]
@@ -504,7 +503,7 @@ class TimeSync(object):
         try:
             # Success!
             response = requests.get(url)
-            return self.__response_to_python(response)
+            return [self.__response_to_python(response)]
         except requests.exceptions.RequestException as e:
             # Request Error
             return [{self.error: e}]

--- a/pymesync/test_mock_pymesync.py
+++ b/pymesync/test_mock_pymesync.py
@@ -554,8 +554,8 @@ class TestMockPymesync(unittest.TestCase):
         self.assertEquals(self.ts.project_users(project="ff"), expected_result)
 
     def test_mock_project_users_no_slug(self):
-        expected_result = [{self.ts.error: "Missing project slug, please "
-                                           "include in method call"}]
+        expected_result = {self.ts.error: "Missing project slug, please "
+                                          "include in method call"}
         self.assertEquals(self.ts.project_users(), expected_result)
 
 

--- a/pymesync/test_mock_pymesync.py
+++ b/pymesync/test_mock_pymesync.py
@@ -16,7 +16,7 @@ class TestMockPymesync(unittest.TestCase):
     def test_mock_authenticate(self):
         self.ts.token = None
         self.assertEquals(self.ts.authenticate("example", "ex", "password"),
-                          [{"token": "TESTTOKEN"}])
+                          {"token": "TESTTOKEN"})
         self.assertEquals(self.ts.token, "TESTTOKEN")
 
     def test_mock_token_expiration_time(self):
@@ -34,7 +34,7 @@ class TestMockPymesync(unittest.TestCase):
             "date_worked": "2014-04-17"
         }
 
-        expected_result = [{
+        expected_result = {
             "duration": 12,
             "user": "example-2",
             "project": "ganeti_web_manager",
@@ -47,7 +47,7 @@ class TestMockPymesync(unittest.TestCase):
             "deleted_at": None,
             "uuid": "838853e3-3635-4076-a26f-7efr4e60981f",
             "revision": 1
-        }]
+        }
         self.assertEquals(self.ts.create_time(parameter_dict), expected_result)
 
     def test_mock_update_time(self):
@@ -56,7 +56,7 @@ class TestMockPymesync(unittest.TestCase):
             "user": "red-leader",
             "activities": ["hello", "world"],
         }
-        updated_param = [{
+        updated_param = {
             "duration": 19,
             "user": "red-leader",
             "activities": ["hello", "world"],
@@ -69,7 +69,7 @@ class TestMockPymesync(unittest.TestCase):
             "deleted_at": None,
             "uuid": "fake-uuid",
             "revision": 2
-        }]
+        }
         self.assertEquals(self.ts.update_time(parameter_dict, "fake-uuid"),
                           updated_param)
 
@@ -84,7 +84,7 @@ class TestMockPymesync(unittest.TestCase):
             "date_worked": "2014-04-17"
         }
 
-        expected_result = [{
+        expected_result = {
             "duration": 12600,
             "user": "example-2",
             "project": "ganeti_web_manager",
@@ -97,7 +97,7 @@ class TestMockPymesync(unittest.TestCase):
             "deleted_at": None,
             "uuid": "838853e3-3635-4076-a26f-7efr4e60981f",
             "revision": 1
-        }]
+        }
         self.assertEquals(self.ts.create_time(parameter_dict), expected_result)
 
     def test_mock_update_time_with_string_duration(self):
@@ -106,7 +106,7 @@ class TestMockPymesync(unittest.TestCase):
             "user": "red-leader",
             "activities": ["hello", "world"],
         }
-        updated_param = [{
+        updated_param = {
             "duration": 12900,
             "user": "red-leader",
             "activities": ["hello", "world"],
@@ -119,7 +119,7 @@ class TestMockPymesync(unittest.TestCase):
             "deleted_at": None,
             "uuid": "fake-uuid",
             "revision": 2
-        }]
+        }
         self.assertEquals(self.ts.update_time(parameter_dict, "fake-uuid"),
                           updated_param)
 
@@ -134,7 +134,7 @@ class TestMockPymesync(unittest.TestCase):
             }
         }
 
-        expected_result = [{
+        expected_result = {
             "uri": "https://code.osuosl.org/projects/timesync",
             "name": "TimeSync API",
             "slugs": ["timesync", "time"],
@@ -147,7 +147,7 @@ class TestMockPymesync(unittest.TestCase):
                 "mrsj": {"member": True, "spectator": True, "manager": True},
                 "thai": {"member": True, "spectator": False, "manager": False}
             }
-        }]
+        }
 
         self.assertEquals(self.ts.create_project(parameter_dict),
                           expected_result)
@@ -158,7 +158,7 @@ class TestMockPymesync(unittest.TestCase):
             "name": "pymesync",
         }
 
-        expected_result = [{
+        expected_result = {
             "uri": "https://code.osuosl.org/projects/timesync",
             "name": "pymesync",
             "slugs": ["ps"],
@@ -179,7 +179,7 @@ class TestMockPymesync(unittest.TestCase):
                     "tschuy"
                 ]
             }
-        }]
+        }
 
         self.assertEquals(self.ts.update_project(parameter_dict, "ps"),
                           expected_result)
@@ -190,7 +190,7 @@ class TestMockPymesync(unittest.TestCase):
             "slug": "qa"
         }
 
-        expected_result = [{
+        expected_result = {
             "name": "Quality Assurance/Testing",
             "slug": "qa",
             "uuid": "cfa07a4f-d446-4078-8d73-2f77560c35c0",
@@ -198,7 +198,7 @@ class TestMockPymesync(unittest.TestCase):
             "updated_at": None,
             "deleted_at": None,
             "revision": 1
-        }]
+        }
 
         self.assertEquals(self.ts.create_activity(parameter_dict),
                           expected_result)
@@ -206,7 +206,7 @@ class TestMockPymesync(unittest.TestCase):
     def test_mock_update_activity(self):
         parameter_dict = {"name": "Code in the wild"}
 
-        expected_result = [{
+        expected_result = {
             "name": "Code in the wild",
             "slug": "ciw",
             "uuid": "3cf78d25-411c-4d1f-80c8-a09e5e12cae3",
@@ -214,7 +214,7 @@ class TestMockPymesync(unittest.TestCase):
             "updated_at": "2014-04-17",
             "deleted_at": None,
             "revision": 2
-        }]
+        }
 
         self.assertEquals(self.ts.update_activity(parameter_dict, "ciw"),
                           expected_result)
@@ -227,7 +227,7 @@ class TestMockPymesync(unittest.TestCase):
             "email": "example@example.com"
         }
 
-        expected_result = [{
+        expected_result = {
             "username": "example",
             "displayname": "X. Ample User",
             "email": "example@example.com",
@@ -235,7 +235,7 @@ class TestMockPymesync(unittest.TestCase):
             "admin": False,
             "created_at": "2015-05-23",
             "deleted_at": None
-        }]
+        }
 
         self.assertEquals(self.ts.create_user(parameter_dict), expected_result)
 
@@ -245,7 +245,7 @@ class TestMockPymesync(unittest.TestCase):
             "email": "red-leader@yavin.com"
         }
 
-        expected_result = [{
+        expected_result = {
             "username": "red-leader",
             "displayname": "Mr. Example",
             "email": "red-leader@yavin.com",
@@ -253,7 +253,7 @@ class TestMockPymesync(unittest.TestCase):
             "admin": False,
             "created_at": "2015-02-29",
             "deleted_at": None
-        }]
+        }
 
         self.assertEquals(self.ts.update_user(parameter_dict, "example"),
                           expected_result)

--- a/pymesync/tests.py
+++ b/pymesync/tests.py
@@ -1435,19 +1435,17 @@ class TestPymesync(unittest.TestCase):
             "updated_at": "2014-07-20"\
         }'
 
-        python_object = [
-            {
-                u"uuid": u"a034806c-00db-4fe1-8de8-514575f31bfb",
-                u"updated_at": u"2014-07-20",
-                u"created_at": u"2014-07-17",
-                u"uri": u"https://code.osuosl.org/projects/ganeti-webmgr",
-                u"name": u"Ganeti Web Manager",
-                u"owner": u"example-user",
-                u"deleted_at": None,
-                u"slugs": [u"ganeti", u"gwm"],
-                u"revision": 4
-            }
-        ]
+        python_object = {
+            u"uuid": u"a034806c-00db-4fe1-8de8-514575f31bfb",
+            u"updated_at": u"2014-07-20",
+            u"created_at": u"2014-07-17",
+            u"uri": u"https://code.osuosl.org/projects/ganeti-webmgr",
+            u"name": u"Ganeti Web Manager",
+            u"owner": u"example-user",
+            u"deleted_at": None,
+            u"slugs": [u"ganeti", u"gwm"],
+            u"revision": 4
+        }
 
         response = resp()
         response.text = json_object
@@ -1531,7 +1529,7 @@ G       methods"""
         response.text = ""
         response.status_code = 200
         self.assertEquals(self.ts._TimeSync__response_to_python(response),
-                          [{"status": 200}])
+                          {"status": 200})
 
     @patch("pymesync.TimeSync._TimeSync__create_or_update")
     def test_create_time(self, mock_create_or_update):
@@ -1887,8 +1885,8 @@ G       methods"""
                                           "password",
                                           "password")
 
-        self.assertEquals(auth_block[0]["token"], self.ts.token, "sometoken")
-        self.assertEquals(auth_block, [{"token": "sometoken"}])
+        self.assertEquals(auth_block["token"], self.ts.token, "sometoken")
+        self.assertEquals(auth_block, {"token": "sometoken"})
 
     def test_authentication_return_error(self):
         """Tests authenticate method with an error return"""
@@ -1906,10 +1904,10 @@ G       methods"""
                                           "password",
                                           "password")
 
-        self.assertEquals(auth_block, [{"status": 401,
-                                        "error": "Authentication failure",
-                                        "text": "Invalid username or "
-                                        "password"}])
+        self.assertEquals(auth_block, {"status": 401,
+                                       "error": "Authentication failure",
+                                       "text": "Invalid username or "
+                                       "password"})
 
     def test_authentication_no_username(self):
         """Tests authenticate method with no username in call"""
@@ -1968,10 +1966,10 @@ G       methods"""
         self.assertEquals(self.ts.authenticate(username="username",
                                                password="password",
                                                auth_type="password"),
-                          [{self.ts.error:
-                            "connection to TimeSync failed at baseurl "
-                            "http://ts.example.com/v1 - "
-                            "response status was 502"}])
+                          {self.ts.error:
+                           "connection to TimeSync failed at baseurl "
+                           "http://ts.example.com/v1 - "
+                           "response status was 502"})
 
     def test_local_auth_error_with_token(self):
         """Test internal local_auth_error method with token"""
@@ -1991,10 +1989,10 @@ G       methods"""
         response.status_code = 502
 
         self.assertEquals(self.ts._TimeSync__response_to_python(response),
-                          [{self.ts.error:
-                            "connection to TimeSync failed at baseurl "
-                            "http://ts.example.com/v1 - "
-                            "response status was 502"}])
+                          {self.ts.error:
+                           "connection to TimeSync failed at baseurl "
+                           "http://ts.example.com/v1 - "
+                           "response status was 502"})
 
     @patch("pymesync.TimeSync._TimeSync__response_to_python")
     def test_delete_object_time(self, m_resp_python):
@@ -2047,15 +2045,15 @@ G       methods"""
         failure"""
         self.ts.token = None
         self.assertEquals(self.ts.delete_time("abcd-3453-3de3-99sh"),
-                          [{"pymesync error":
-                            "Not authenticated with TimeSync, "
-                            "call self.authenticate() first"}])
+                          {"pymesync error":
+                           "Not authenticated with TimeSync, "
+                           "call self.authenticate() first"})
 
     def test_delete_time_no_uuid(self):
         """Test that delete_time returns proper error when uuid not provided"""
         self.assertEquals(self.ts.delete_time(),
-                          [{"pymesync error":
-                            "missing uuid; please add to method call"}])
+                          {"pymesync error":
+                           "missing uuid; please add to method call"})
 
     @patch("pymesync.TimeSync._TimeSync__delete_object")
     def test_delete_project(self, m_delete_object):
@@ -2068,16 +2066,16 @@ G       methods"""
         failure"""
         self.ts.token = None
         self.assertEquals(self.ts.delete_project("ts"),
-                          [{"pymesync error":
-                            "Not authenticated with TimeSync, "
-                            "call self.authenticate() first"}])
+                          {"pymesync error":
+                           "Not authenticated with TimeSync, "
+                           "call self.authenticate() first"})
 
     def test_delete_project_no_slug(self):
         """Test that delete_project returns proper error when slug not
         provided"""
         self.assertEquals(self.ts.delete_project(),
-                          [{"pymesync error":
-                            "missing slug; please add to method call"}])
+                          {"pymesync error":
+                           "missing slug; please add to method call"})
 
     @patch("pymesync.TimeSync._TimeSync__delete_object")
     def test_delete_activity(self, m_delete_object):
@@ -2090,16 +2088,16 @@ G       methods"""
         failure"""
         self.ts.token = None
         self.assertEquals(self.ts.delete_activity("code"),
-                          [{"pymesync error":
-                            "Not authenticated with TimeSync, "
-                            "call self.authenticate() first"}])
+                          {"pymesync error":
+                           "Not authenticated with TimeSync, "
+                           "call self.authenticate() first"})
 
     def test_delete_activity_no_slug(self):
         """Test that delete_activity returns proper error when slug not
         provided"""
         self.assertEquals(self.ts.delete_activity(),
-                          [{"pymesync error":
-                            "missing slug; please add to method call"}])
+                          {"pymesync error":
+                           "missing slug; please add to method call"})
 
     @patch("pymesync.TimeSync._TimeSync__delete_object")
     def test_delete_user(self, m_delete_object):
@@ -2112,16 +2110,16 @@ G       methods"""
         failure"""
         self.ts.token = None
         self.assertEquals(self.ts.delete_user("example-user"),
-                          [{"pymesync error":
-                            "Not authenticated with TimeSync, "
-                            "call self.authenticate() first"}])
+                          {"pymesync error":
+                           "Not authenticated with TimeSync, "
+                           "call self.authenticate() first"})
 
     def test_delete_user_no_username(self):
         """Test that delete_user returns proper error when username not
         provided"""
         self.assertEquals(self.ts.delete_user(),
-                          [{"pymesync error":
-                            "missing username; please add to method call"}])
+                          {"pymesync error":
+                           "missing username; please add to method call"})
 
     def test_token_expiration_valid(self):
         """Test that token_expiration_time returns valid date from a valid
@@ -2143,15 +2141,15 @@ G       methods"""
         """Test that token_expiration_time returns correct from an invalid
         token"""
         self.assertEquals(self.ts.token_expiration_time(),
-                          [{self.ts.error: "improperly encoded token"}])
+                          {self.ts.error: "improperly encoded token"})
 
     def test_token_expiration_no_auth(self):
         """Test that token_expiration_time returns correct error when user is
         not authenticated"""
         self.ts.token = None
         self.assertEquals(self.ts.token_expiration_time(),
-                          [{self.ts.error: "Not authenticated with TimeSync, "
-                                           "call self.authenticate() first"}])
+                          {self.ts.error: "Not authenticated with TimeSync, "
+                                          "call self.authenticate() first"})
 
     def test_duration_to_seconds(self):
         """Tests that when a string duration is entered, it is converted to an
@@ -2284,18 +2282,19 @@ G       methods"""
                                             return_value=response)
 
         self.assertEquals(self.ts.project_users(project=proj),
-                          [{u"error": u"Object not found",
-                            u"text": u"Nonexistent project"}])
+                          {u"error": u"Object not found",
+                           u"text": u"Nonexistent project"})
 
     def test_project_users_no_project_parameter(self):
         """Test project_users method with no project object passed as a
         parameter, should return an error"""
         self.assertEquals(self.ts.project_users(),
-                          [{self.ts.error: "Missing project slug, please "
-                                           "include in method call"}])
+                          {self.ts.error: "Missing project slug, please "
+                                          "include in method call"})
 
 if __name__ == "__main__":
-    actual_post = requests.post  # Save this for testing exceptions
+    # Save these for resetting mocked methods
+    actual_post = requests.post
     actual_delete = requests.delete
     actual_get = requests.get
     unittest.main()

--- a/pymesync/tests.py
+++ b/pymesync/tests.py
@@ -157,8 +157,8 @@ class TestPymesync(unittest.TestCase):
 
         self.assertEquals(self.ts._TimeSync__create_or_update(time, None,
                                                               "time", "times"),
-                          [{self.ts.error:
-                            "time object: invalid field: bad"}])
+                          {self.ts.error:
+                           "time object: invalid field: bad"})
 
     def test_create_or_update_create_time_two_required_missing(self):
         """Tests TimeSync._TimeSync__create_or_update for create time with
@@ -174,9 +174,9 @@ class TestPymesync(unittest.TestCase):
 
         self.assertEquals(self.ts._TimeSync__create_or_update(time, None,
                                                               "time", "times"),
-                          [{self.ts.error:
-                            "time object: missing required field(s): "
-                            "project, activities"}])
+                          {self.ts.error:
+                           "time object: missing required field(s): "
+                           "project, activities"})
 
     def test_create_or_update_create_time_each_required_missing(self):
         """Tests TimeSync._TimeSync__create_or_update to create time with
@@ -196,8 +196,8 @@ class TestPymesync(unittest.TestCase):
             del(time_to_test[key])
             self.assertEquals(self.ts._TimeSync__create_or_update(
                               time_to_test, None, "time", "times"),
-                              [{self.ts.error: "time object: "
-                                "missing required field(s): {}".format(key)}])
+                              {self.ts.error: "time object: "
+                               "missing required field(s): {}".format(key)})
             time_to_test = dict(time)
 
     def test_create_or_update_create_time_type_error(self):
@@ -211,8 +211,8 @@ class TestPymesync(unittest.TestCase):
                                                                   None,
                                                                   "time",
                                                                   "times"),
-                              [{self.ts.error:
-                                "time object: must be python dictionary"}])
+                              {self.ts.error:
+                               "time object: must be python dictionary"})
 
     @patch("pymesync.TimeSync._TimeSync__response_to_python")
     def test_create_or_update_create_time_catch_request_error(self, m):
@@ -341,8 +341,8 @@ class TestPymesync(unittest.TestCase):
 
         self.assertEquals(self.ts._TimeSync__create_or_update(user, None,
                                                               "user", "users"),
-                          [{self.ts.error:
-                            "user object: invalid field: bad"}])
+                          {self.ts.error:
+                           "user object: invalid field: bad"})
 
     def test_create_or_update_create_user_two_required_missing(self):
         """Tests TimeSync._TimeSync__create_or_update for create user with missing
@@ -355,9 +355,9 @@ class TestPymesync(unittest.TestCase):
 
         self.assertEquals(self.ts._TimeSync__create_or_update(user, None,
                                                               "user", "users"),
-                          [{self.ts.error:
-                            "user object: missing required field(s): "
-                            "username, password"}])
+                          {self.ts.error:
+                           "user object: missing required field(s): "
+                           "username, password"})
 
     def test_create_or_update_create_user_each_required_missing(self):
         """Tests TimeSync._TimeSync__create_or_update to create user with
@@ -374,8 +374,8 @@ class TestPymesync(unittest.TestCase):
             del(user_to_test[key])
             self.assertEquals(self.ts._TimeSync__create_or_update(
                               user_to_test, None, "user", "users"),
-                              [{self.ts.error: "user object: "
-                                "missing required field(s): {}".format(key)}])
+                              {self.ts.error: "user object: "
+                               "missing required field(s): {}".format(key)})
             user_to_test = dict(user)
 
     def test_create_or_update_create_user_type_error(self):
@@ -389,8 +389,8 @@ class TestPymesync(unittest.TestCase):
                                                                   None,
                                                                   "user",
                                                                   "users"),
-                              [{self.ts.error:
-                                "user object: must be python dictionary"}])
+                              {self.ts.error:
+                               "user object: must be python dictionary"})
 
     @patch("pymesync.TimeSync._TimeSync__response_to_python")
     def test_create_or_update_create_user_catch_request_error(self, m):
@@ -523,8 +523,8 @@ class TestPymesync(unittest.TestCase):
                                                               None,
                                                               "project",
                                                               "projects"),
-                          [{self.ts.error:
-                            "project object: invalid field: bad"}])
+                          {self.ts.error:
+                           "project object: invalid field: bad"})
 
     def test_create_or_update_create_project_required_missing(self):
         """Tests TimeSync._TimeSync__create_or_update for create project with
@@ -538,8 +538,8 @@ class TestPymesync(unittest.TestCase):
                                                               None,
                                                               "project",
                                                               "project"),
-                          [{self.ts.error: "project object: "
-                            "missing required field(s): name"}])
+                          {self.ts.error: "project object: "
+                           "missing required field(s): name"})
 
     def test_create_or_update_create_project_each_required_missing(self):
         """Tests TimeSync._TimeSync__create_or_update for create project with
@@ -556,8 +556,8 @@ class TestPymesync(unittest.TestCase):
             del(project_to_test[key])
             self.assertEquals(self.ts._TimeSync__create_or_update(
                               project_to_test, None, "project", "projects"),
-                              [{self.ts.error: "project object: "
-                                "missing required field(s): {}".format(key)}])
+                              {self.ts.error: "project object: "
+                               "missing required field(s): {}".format(key)})
             project_to_test = dict(project)
 
     def test_create_or_update_create_project_type_error(self):
@@ -571,8 +571,8 @@ class TestPymesync(unittest.TestCase):
                                                                   None,
                                                                   "project",
                                                                   "projects"),
-                              [{self.ts.error:
-                                "project object: must be python dictionary"}])
+                              {self.ts.error:
+                               "project object: must be python dictionary"})
 
     @patch("pymesync.TimeSync._TimeSync__response_to_python")
     def test_create_or_update_create_activity_valid(self, m_resp_python):
@@ -671,8 +671,8 @@ class TestPymesync(unittest.TestCase):
                                                               None,
                                                               "activity",
                                                               "activites"),
-                          [{self.ts.error:
-                            "activity object: invalid field: bad"}])
+                          {self.ts.error:
+                           "activity object: invalid field: bad"})
 
     def test_create_or_update_create_activity_required_missing(self):
         """Tests TimeSync._TimeSync__create_or_update for create activity with
@@ -686,8 +686,8 @@ class TestPymesync(unittest.TestCase):
                                                               None,
                                                               "activity",
                                                               "activities"),
-                          [{self.ts.error: "activity object: "
-                            "missing required field(s): slug"}])
+                          {self.ts.error: "activity object: "
+                           "missing required field(s): slug"})
 
     def test_create_or_update_create_activity_each_required_missing(self):
         """Tests TimeSync._TimeSync__create_or_update for create activity with
@@ -705,8 +705,8 @@ class TestPymesync(unittest.TestCase):
             self.assertEquals(self.ts._TimeSync__create_or_update(
                               activity_to_test, None,
                               "activity", "activities"),
-                              [{self.ts.error: "activity object: "
-                                "missing required field(s): {}".format(key)}])
+                              {self.ts.error: "activity object: "
+                               "missing required field(s): {}".format(key)})
             activity_to_test = dict(activity)
 
     def test_create_or_update_create_activity_type_error(self):
@@ -718,8 +718,8 @@ class TestPymesync(unittest.TestCase):
         for param in param_list:
             self.assertEquals(self.ts._TimeSync__create_or_update(param,
                               None, "activity", "activities"),
-                              [{self.ts.error:
-                                "activity object: must be python dictionary"}])
+                              {self.ts.error:
+                               "activity object: must be python dictionary"})
 
     @patch("pymesync.TimeSync._TimeSync__response_to_python")
     def test_create_or_update_create_time_no_auth(self, m_resp_python):
@@ -741,8 +741,8 @@ class TestPymesync(unittest.TestCase):
         # Send it
         self.assertEquals(self.ts._TimeSync__create_or_update(time, None,
                                                               "time", "times"),
-                          [{self.ts.error: "Not authenticated with "
-                            "TimeSync, call self.authenticate() first"}])
+                          {self.ts.error: "Not authenticated with "
+                           "TimeSync, call self.authenticate() first"})
 
     @patch("pymesync.TimeSync._TimeSync__response_to_python")
     def test_create_or_update_create_project_no_auth(self, m_resp_python):
@@ -762,8 +762,8 @@ class TestPymesync(unittest.TestCase):
                                                               None,
                                                               "project",
                                                               "projects"),
-                          [{self.ts.error: "Not authenticated with "
-                            "TimeSync, call self.authenticate() first"}])
+                          {self.ts.error: "Not authenticated with "
+                           "TimeSync, call self.authenticate() first"})
 
     @patch("pymesync.TimeSync._TimeSync__response_to_python")
     def test_create_or_update_create_activity_no_auth(self, m_resp_python):
@@ -782,8 +782,8 @@ class TestPymesync(unittest.TestCase):
                                                               None,
                                                               "activity",
                                                               "activities"),
-                          [{self.ts.error: "Not authenticated with "
-                            "TimeSync, call self.authenticate() first"}])
+                          {self.ts.error: "Not authenticated with "
+                           "TimeSync, call self.authenticate() first"})
 
     @patch("pymesync.TimeSync._TimeSync__response_to_python")
     def test_create_or_update_update_time_no_auth(self, m_resp_python):
@@ -808,8 +808,8 @@ class TestPymesync(unittest.TestCase):
                                                               "time",
                                                               "times",
                                                               False),
-                          [{self.ts.error: "Not authenticated with "
-                            "TimeSync, call self.authenticate() first"}])
+                          {self.ts.error: "Not authenticated with "
+                           "TimeSync, call self.authenticate() first"})
 
     @patch("pymesync.TimeSync._TimeSync__response_to_python")
     def test_create_or_update_update_project_no_auth(self, m_resp_python):
@@ -830,8 +830,8 @@ class TestPymesync(unittest.TestCase):
                                                               "project",
                                                               "project",
                                                               False),
-                          [{self.ts.error: "Not authenticated with "
-                            "TimeSync, call self.authenticate() first"}])
+                          {self.ts.error: "Not authenticated with "
+                           "TimeSync, call self.authenticate() first"})
 
     @patch("pymesync.TimeSync._TimeSync__response_to_python")
     def test_create_or_update_update_activity_no_auth(self, m_resp_python):
@@ -851,8 +851,8 @@ class TestPymesync(unittest.TestCase):
                                                               "activity",
                                                               "activities",
                                                               False),
-                          [{self.ts.error: "Not authenticated with "
-                            "TimeSync, call self.authenticate() first"}])
+                          {self.ts.error: "Not authenticated with "
+                           "TimeSync, call self.authenticate() first"})
 
     def test_auth(self):
         """Tests TimeSync._TimeSync__auth function"""
@@ -1582,8 +1582,8 @@ G       methods"""
         }
 
         self.assertEquals(self.ts.create_time(time),
-                          [{self.ts.error:
-                            "time object: duration cannot be negative"}])
+                          {self.ts.error:
+                           "time object: duration cannot be negative"})
 
     def test_update_time_with_negative_duration(self):
         """Tests that TimeSync.update_time will return an error if a negative
@@ -1599,8 +1599,8 @@ G       methods"""
         }
 
         self.assertEquals(self.ts.update_time(time, "uuid"),
-                          [{self.ts.error:
-                            "time object: duration cannot be negative"}])
+                          {self.ts.error:
+                           "time object: duration cannot be negative"})
 
     @patch("pymesync.TimeSync._TimeSync__create_or_update")
     def test_create_time_with_string_duration(self, mock_create_or_update):
@@ -1834,8 +1834,8 @@ G       methods"""
             user_to_test = dict(user)
             user_to_test[perm] = "invalid"
             self.assertEquals(self.ts.create_user(user_to_test),
-                              [{self.ts.error: "user object: {} must be "
-                                               "True or False".format(perm)}])
+                              {self.ts.error: "user object: {} must be "
+                                              "True or False".format(perm)})
 
     @patch("pymesync.TimeSync._TimeSync__create_or_update")
     def test_update_user(self, mock_create_or_update):
@@ -1913,46 +1913,46 @@ G       methods"""
         """Tests authenticate method with no username in call"""
         self.assertEquals(self.ts.authenticate(password="password",
                                                auth_type="password"),
-                          [{self.ts.error: "Missing username; "
-                            "please add to method call"}])
+                          {self.ts.error: "Missing username; "
+                           "please add to method call"})
 
     def test_authentication_no_password(self):
         """Tests authenticate method with no password in call"""
         self.assertEquals(self.ts.authenticate(username="username",
                                                auth_type="password"),
-                          [{self.ts.error: "Missing password; "
-                            "please add to method call"}])
+                          {self.ts.error: "Missing password; "
+                           "please add to method call"})
 
     def test_authentication_no_auth_type(self):
         """Tests authenticate method with no auth_type in call"""
         self.assertEquals(self.ts.authenticate(password="password",
                                                username="username"),
-                          [{self.ts.error: "Missing auth_type; "
-                            "please add to method call"}])
+                          {self.ts.error: "Missing auth_type; "
+                           "please add to method call"})
 
     def test_authentication_no_username_or_password(self):
         """Tests authenticate method with no username or password in call"""
         self.assertEquals(self.ts.authenticate(auth_type="password"),
-                          [{self.ts.error: "Missing username, password; "
-                            "please add to method call"}])
+                          {self.ts.error: "Missing username, password; "
+                           "please add to method call"})
 
     def test_authentication_no_username_or_auth_type(self):
         """Tests authenticate method with no username or auth_type in call"""
         self.assertEquals(self.ts.authenticate(password="password"),
-                          [{self.ts.error: "Missing username, auth_type; "
-                            "please add to method call"}])
+                          {self.ts.error: "Missing username, auth_type; "
+                           "please add to method call"})
 
     def test_authentication_no_password_or_auth_type(self):
         """Tests authenticate method with no username or auth_type in call"""
         self.assertEquals(self.ts.authenticate(username="username"),
-                          [{self.ts.error: "Missing password, auth_type; "
-                            "please add to method call"}])
+                          {self.ts.error: "Missing password, auth_type; "
+                           "please add to method call"})
 
     def test_authentication_no_arguments(self):
         """Tests authenticate method with no arguments in call"""
         self.assertEquals(self.ts.authenticate(),
-                          [{self.ts.error: "Missing username, password, "
-                            "auth_type; please add to method call"}])
+                          {self.ts.error: "Missing username, password, "
+                           "auth_type; please add to method call"})
 
     def test_authentication_no_token_in_response(self):
         """Tests authenticate method with no token in response"""
@@ -2199,8 +2199,8 @@ G       methods"""
         }
 
         self.assertEquals(self.ts.create_time(time),
-                          [{self.ts.error:
-                            "time object: duration cannot be negative"}])
+                          {self.ts.error:
+                           "time object: duration cannot be negative"})
 
     def test_project_users_valid(self):
         """Test project_users method with a valid project object returned from


### PR DESCRIPTION
Fixes #109
- `get_*` returns dict(s) within a list
- `create_*` returns a dict
- `update_*` returns a dict
- `authenticate()` returns a dict
- other simple data returns (that don't return multiple objects)
  also return a dict or single element (e.g. datetime)
- error message returns are formatted identically to their parent
  method