### PR TITLE
Fix optional params for users

### DIFF
--- a/docs/source/testing.rst
+++ b/docs/source/testing.rst
@@ -123,18 +123,18 @@ An (almost) exhaustive example of test mode:
   >>> user = {
   ...    "username": "example",
   ...    "password": "password",
-  ...    "displayname": "X. Ample User",
+  ...    "display_name": "X. Ample User",
   ...    "email": "example@example.com"
   ...}
   >>> ts.create_user(user=user)
-  [{'username': 'example', 'deleted_at': None, 'displayname': 'X. Ample User', 'admin': False, 'created_at': '2015-05-23', 'active': True, 'email': 'example@example.com'}]
+  [{'username': 'example', 'deleted_at': None, 'display_name': 'X. Ample User', 'site_manager': False, 'site_spectator': False, 'site_admin': False, 'created_at': '2015-05-23', 'active': True, 'email': 'example@example.com'}]
   >>>
   >>> user = {
   ...    "username": "red-leader",
   ...    "email": "red-leader@yavin.com"
   ...}
   >>> ts.update_user(user=user, username="example")
-  [{'username': 'red-leader', 'displayname': 'Mr. Example', 'admin': False, 'created_at': '2015-02-29', 'active': True, 'deleted_at': None, 'email': 'red-leader@yavin.com'}]
+  [{'username': 'red-leader', 'display_name': 'Mr. Example', 'site_manager': False, 'site_spectator': False, 'site_admin': False, 'created_at': '2015-02-29', 'active': True, 'deleted_at': None, 'email': 'red-leader@yavin.com'}]
   >>>
   >>> ts.get_times()
   [{'activities': ['docs', 'planning'], 'date_worked': '2014-04-17', 'updated_at': None, 'user': 'userone', 'duration': 12, 'deleted_at': None, 'uuid': 'c3706e79-1c9a-4765-8d7f-89b4544cad56', 'notes': 'Worked on documentation.', 'project': ['ganeti-webmgr', 'gwm'], 'issue_uri': 'https://github.com/osuosl/ganeti_webmgr', 'created_at': '2014-04-17', 'revision': 1}, {'activities': ['code', 'planning'], 'date_worked': '2014-04-17', 'updated_at': None, 'user': 'usertwo', 'duration': 13, 'deleted_at': None, 'uuid': '12345676-1c9a-rrrr-bbbb-89b4544cad56', 'notes': 'Worked on coding', 'project': ['ganeti-webmgr', 'gwm'], 'issue_uri': 'https://github.com/osuosl/ganeti_webmgr', 'created_at': '2014-04-17', 'revision': 1}, {'activities': ['code'], 'date_worked': '2014-04-17', 'updated_at': None, 'user': 'userthree', 'duration': 14, 'deleted_at': None, 'uuid': '12345676-1c9a-ssss-cccc-89b4544cad56', 'notes': 'Worked on coding', 'project': ['timesync', 'ts'], 'issue_uri': 'https://github.com/osuosl/timesync', 'created_at': '2014-04-17', 'revision': 1}]
@@ -146,7 +146,7 @@ An (almost) exhaustive example of test mode:
   [{'uuid': 'adf036f5-3d49-4a84-bef9-062b46380bbf', 'created_at': '2014-04-17', 'updated_at': None, 'name': 'Documentation', 'deleted_at': None, 'slugs': ['docs'], 'revision': 5}, {'uuid': 'adf036f5-3d49-bbbb-rrrr-062b46380bbf', 'created_at': '2014-04-17', 'updated_at': None, 'name': 'Coding', 'deleted_at': None, 'slugs': ['code', 'dev'], 'revision': 1}, {'uuid': 'adf036f5-3d49-cccc-ssss-062b46380bbf', 'created_at': '2014-04-17', 'updated_at': None, 'name': 'Planning', 'deleted_at': None, 'slugs': ['plan', 'prep'], 'revision': 1}]
   >>>
   >>> ts.get_users()
-  [{'username': 'userone', 'displayname': 'One Is The Loneliest Number', 'admin': False, 'created_at': '2015-02-29', 'active': True, 'deleted_at': None, 'email': 'exampleone@example.com'}, {'username': 'usertwo', 'displayname': 'Two Can Be As Bad As One', 'admin': False, 'created_at': '2015-02-29', 'active': True, 'deleted_at': None, 'email': 'exampletwo@example.com'}, {'username': 'userthree', 'displayname': "Yes It's The Saddest Experience", 'admin': False, 'created_at': '2015-02-29', 'active': True, 'deleted_at': None, 'email': 'examplethree@example.com'}, {'username': 'userfour', 'displayname': "You'll Ever Do", 'admin': False, 'created_at': '2015-02-29', 'active': True, 'deleted_at': None, 'email': 'examplefour@example.com'}]
+  [{'username': 'userone', 'display_name': 'One Is The Loneliest Number', 'site_manager': False, 'site_admin': False, 'site_spectator': False, 'created_at': '2015-02-29', 'active': True, 'deleted_at': None, 'email': 'exampleone@example.com'}, {'username': 'usertwo', 'display_name': 'Two Can Be As Bad As One', 'site_admin': False, 'created_at': '2015-02-29', 'active': True, 'deleted_at': None, 'email': 'exampletwo@example.com'}, {'username': 'userthree', 'display_name': "Yes It's The Saddest Experience", 'site_admin': False, 'created_at': '2015-02-29', 'active': True, 'deleted_at': None, 'email': 'examplethree@example.com'}, {'username': 'userfour', 'display_name': "You'll Ever Do", 'site_admin': False, 'created_at': '2015-02-29', 'active': True, 'deleted_at': None, 'email': 'examplefour@example.com'}]
   >>>
   >>> ts.get_times({"uuid": "some-uuid"})
   [{'activities': ['docs', 'planning'], 'date_worked': '2014-04-17', 'updated_at': None, 'user': 'userone', 'duration': 12, 'deleted_at': None, 'uuid': 'some-uuid', 'notes': 'Worked on documentation.', 'project': ['ganeti-webmgr', 'gwm'], 'issue_uri': 'https://github.com/osuosl/ganeti_webmgr', 'created_at': '2014-04-17', 'revision': 1}]

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -546,7 +546,7 @@ TimeSync.\ **get_users(username=None)**
     .. code-block:: python
 
       >>> ts.get_users()
-      [{u'username': u'userone', u'displayname': u'One Is The Loneliest Number', u'admin': False, u'created_at': u'2015-02-29', u'active': True, u'deleted_at': None, u'email': u'exampleone@example.com'}, {u'username': u'usertwo', u'displayname': u'Two Can Be As Bad As One', u'admin': False, u'created_at': u'2015-02-29', u'active': True, u'deleted_at': None, u'email': u'exampletwo@example.com'}, {u'username': u'userthree', u'displayname': u'Yes Its The Saddest Experience', u'admin': False, u'created_at': u'2015-02-29', u'active': True, u'deleted_at': None, u'email': u'examplethree@example.com'}, {u'username': u'userfour', u'displayname': u'Youll Ever Do', u'admin': False, u'created_at': u'2015-02-29', u'active': True, u'deleted_at': None, u'email': u'examplefour@example.com'}]
+      [{u'username': u'userone', u'display_name': u'One Is The Loneliest Number', u'site_admin': False, u'site_spectator': False, u'site_spectator': False, u'created_at': u'2015-02-29', u'active': True, u'deleted_at': None, u'email': u'exampleone@example.com'}, {u'username': u'usertwo', u'display_name': u'Two Can Be As Bad As One', u'site_admin': False, u'site_spectator': False, u'site_manager': False, u'created_at': u'2015-02-29', u'active': True, u'deleted_at': None, u'email': u'exampletwo@example.com'}, {u'username': u'userthree', u'display_name': u'Yes Its The Saddest Experience', u'site_admin': False, u'site_spectator': False, u'site_manager': False, u'created_at': u'2015-02-29', u'active': True, u'deleted_at': None, u'email': u'examplethree@example.com'}, {u'username': u'userfour', u'display_name': u'Youll Ever Do', u'site_admin': False, u'site_manager': False, u'site_spectator': False, u'created_at': u'2015-02-29', u'active': True, u'deleted_at': None, u'email': u'examplefour@example.com'}]
       >>>
 
 ------------------------------------------
@@ -760,11 +760,11 @@ TimeSync.\ **create_user(user)**
 
     Additionally, the following parameters may be optionally included:
 
-    * ``"displayname"``
+    * ``"display_name"``
     * ``"email"``
-    * ``"admin"`` - sitewide permission, must be a boolean
-    * ``"spectator"`` - sitewide permission , must be a boolean
-    * ``"manager"`` - sitewide permission, must be a boolean
+    * ``"site_admin"`` - sitewide permission, must be a boolean
+    * ``"site_spectator"`` - sitewide permission , must be a boolean
+    * ``"site_manager"`` - sitewide permission, must be a boolean
     * ``"active"`` - user status, usually set internally, must be a boolean
 
     Example usage:
@@ -774,11 +774,11 @@ TimeSync.\ **create_user(user)**
       >>> user = {
       ...    "username": "example",
       ...    "password": "password",
-      ...    "displayname": "X. Ample User",
+      ...    "display_name": "X. Ample User",
       ...    "email": "example@example.com"
       ...}
       >>> ts.create_user(user=user)
-      {u'username': u'example', u'deleted_at': None, u'displayname': u'X. Ample User', u'admin': False, u'created_at': u'2015-05-23', u'active': True, u'email': u'example@example.com'}
+      {u'username': u'example', u'deleted_at': None, u'display_name': u'X. Ample User', u'site_admin': False, u'site_manager': False, u'site_spectator': False, u'created_at': u'2015-05-23', u'active': True, u'email': u'example@example.com'}
       >>>
 
 ------------------------------------------
@@ -802,8 +802,11 @@ TimeSync.\ **update_user(user, username)**
 
     * ``"username"``
     * ``"password"``
-    * ``"displayname"``
+    * ``"display_name"``
     * ``"email"``
+    * ``"site_admin"``
+    * ``"site_manager"``
+    * ``"site_spectator"``
 
     Example usage:
 
@@ -814,7 +817,7 @@ TimeSync.\ **update_user(user, username)**
       ...    "email": "red-leader@yavin.com"
       ...}
       >>> ts.update_user(user=user, username="example")
-      {u'username': u'red-leader', u'displayname': u'Mr. Example', u'admin': False, u'created_at': u'2015-02-29', u'active': True, u'deleted_at': None, u'email': u'red-leader@yavin.com'}
+      {u'username': u'red-leader', u'display_name': u'Mr. Example', u'site_admin': False, u'site_spectator': False, u'site_manager': False, u'created_at': u'2015-02-29', u'active': True, u'deleted_at': None, u'email': u'red-leader@yavin.com'}
       >>>
 
 ------------------------------------------

--- a/pymesync/mock_pymesync.py
+++ b/pymesync/mock_pymesync.py
@@ -111,7 +111,12 @@ def update_activity(p_dict, slug):
 def create_user(p_dict):
     """Creates a user"""
     p_dict["active"] = True
-    p_dict["admin"] = False
+    p_dict["site_admin"] = False if "site_admin" not in p_dict else (
+            p_dict["site_admin"])
+    p_dict["site_manager"] = False if "site_manager" not in p_dict else (
+            p_dict["site_manager"])
+    p_dict["site_spectator"] = False if "site_spectator" not in p_dict else (
+            p_dict["site_spectator"])
     p_dict["created_at"] = "2015-05-23"
     p_dict["deleted_at"] = None
     del(p_dict["password"])
@@ -122,12 +127,17 @@ def update_user(p_dict, username):
     """Updates user by username"""
     updated_param = {
         "username": p_dict["username"] if "username" in p_dict else username,
-        "displayname": p_dict["displayname"] if "displayname" in p_dict else (
+        "display_name": p_dict["display_name"] if "display_name" in p_dict else (
             "Mr. Example"),
         "email": p_dict["email"] if "email" in p_dict else (
             "examplej@example.com"),
         "active": True,
-        "admin": False,
+        "site_admin": False if "site_admin" not in p_dict else (
+            p_dict["site_admin"]),
+        "site_manager": False if "site_manager" not in p_dict else (
+            p_dict["site_manager"]),
+        "site_spectator": False if "site_spectator" not in p_dict else (
+            p_dict["site_spectator"]),
         "created_at": "2015-02-29",
         "deleted_at": None
     }
@@ -319,10 +329,12 @@ def get_users(username):
     if username:
         p_dict = [{
             "username": username,
-            "displayname": "X. Ample User",
+            "display_name": "X. Ample User",
             "email": "example@example.com",
             "active": True,
-            "admin": False,
+            "site_admin": False,
+            "site_spectator": False,
+            "site_manager": False,
             "created_at": "2015-02-29",
             "deleted_at": None
         }]
@@ -330,37 +342,45 @@ def get_users(username):
         p_dict = [
             {
                 "username": "userone",
-                "displayname": "One Is The Loneliest Number",
+                "display_name": "One Is The Loneliest Number",
                 "email": "exampleone@example.com",
                 "active": True,
-                "admin": False,
+                "site_admin": False,
+                "site_manager": False,
+                "site_spectator": False,
                 "created_at": "2015-02-29",
                 "deleted_at": None
             },
             {
                 "username": "usertwo",
-                "displayname": "Two Can Be As Bad As One",
+                "display_name": "Two Can Be As Bad As One",
                 "email": "exampletwo@example.com",
                 "active": True,
-                "admin": False,
+                "site_admin": False,
+                "site_manager": False,
+                "site_spectator": False,    
                 "created_at": "2015-02-29",
                 "deleted_at": None
             },
             {
                 "username": "userthree",
-                "displayname": "Yes It's The Saddest Experience",
+                "display_name": "Yes It's The Saddest Experience",
                 "email": "examplethree@example.com",
                 "active": True,
-                "admin": False,
+                "site_admin": False,
+                "site_manager": False,
+                "site_spectator": False,    
                 "created_at": "2015-02-29",
                 "deleted_at": None
             },
             {
                 "username": "userfour",
-                "displayname": "You'll Ever Do",
+                "display_name": "You'll Ever Do",
                 "email": "examplefour@example.com",
                 "active": True,
-                "admin": False,
+                "site_admin": False,
+                "site_manager": False,
+                "site_spectator": False,    
                 "created_at": "2015-02-29",
                 "deleted_at": None
             }

--- a/pymesync/pymesync.py
+++ b/pymesync/pymesync.py
@@ -329,7 +329,7 @@ class TimeSync(object):
         try:
             # Success!
             response = requests.get(url)
-            return [self.__response_to_python(response)]
+            return self.__response_to_python(response)
         except requests.exceptions.RequestException as e:
             # Request Error
             return [{self.error: e}]
@@ -397,7 +397,7 @@ class TimeSync(object):
         try:
             # Success!
             response = requests.get(url)
-            return [self.__response_to_python(response)]
+            return self.__response_to_python(response)
         except requests.exceptions.RequestException as e:
             # Request Error
             return [{self.error: e}]
@@ -465,7 +465,7 @@ class TimeSync(object):
         try:
             # Success!
             response = requests.get(url)
-            return [self.__response_to_python(response)]
+            return self.__response_to_python(response)
         except requests.exceptions.RequestException as e:
             # Request Error
             return [{self.error: e}]
@@ -506,7 +506,7 @@ class TimeSync(object):
         try:
             # Success!
             response = requests.get(url)
-            return [self.__response_to_python(response)]
+            return self.__response_to_python(response)
         except requests.exceptions.RequestException as e:
             # Request Error
             return [{self.error: e}]

--- a/pymesync/pymesync.py
+++ b/pymesync/pymesync.py
@@ -55,7 +55,7 @@ class TimeSync(object):
             "time":     ["notes", "issue_uri"],
             "project":  ["uri", "users", "default_activity"],
             "activity": [],
-            "user":     ["display_name", "email", "site_admin", 
+            "user":     ["display_name", "email", "site_admin",
                          "site_spectator", "site_manager", "meta", "active"],
         }
 

--- a/pymesync/pymesync.py
+++ b/pymesync/pymesync.py
@@ -45,18 +45,18 @@ class TimeSync(object):
                                   "start", "end", "include_revisions",
                                   "include_deleted", "uuid"]
         self.required_params = {
-            "time": ["duration", "project", "user",
-                     "activities", "date_worked"],
-            "project": ["name", "slugs"],
+            "time":     ["duration", "project", "user",
+                         "activities", "date_worked"],
+            "project":  ["name", "slugs"],
             "activity": ["name", "slug"],
-            "user": ["username", "password"],
+            "user":     ["username", "password"],
         }
         self.optional_params = {
-            "time": ["notes", "issue_uri"],
-            "project": ["uri", "users"],
+            "time":     ["notes", "issue_uri"],
+            "project":  ["uri", "users", "default_activity"],
             "activity": [],
-            "user": ["displayname", "email", "admin", "spectator",
-                     "manager", "admin", "meta", "active"],
+            "user":     ["display_name", "email", "site_admin", 
+                         "site_spectator", "site_manager", "meta", "active"],
         }
 
     def authenticate(self, username=None, password=None, auth_type=None):
@@ -253,7 +253,7 @@ class TimeSync(object):
         ``user`` is a python dictionary containing the user information to send
         to TimeSync.
         """
-        for perm in ["admin", "manager", "spectator", "active"]:
+        for perm in ["site_admin", "site_manager", "site_spectator", "active"]:
             if perm in user and not isinstance(user[perm], bool):
                 return {self.error: "user object: "
                         "{} must be True or False".format(perm)}

--- a/pymesync/test_mock_pymesync.py
+++ b/pymesync/test_mock_pymesync.py
@@ -223,16 +223,18 @@ class TestMockPymesync(unittest.TestCase):
         parameter_dict = {
             "username": "example",
             "password": "password",
-            "displayname": "X. Ample User",
+            "display_name": "X. Ample User",
             "email": "example@example.com"
         }
 
         expected_result = {
             "username": "example",
-            "displayname": "X. Ample User",
+            "display_name": "X. Ample User",
             "email": "example@example.com",
             "active": True,
-            "admin": False,
+            "site_admin": False,
+            "site_manager": False,
+            "site_spectator": False,
             "created_at": "2015-05-23",
             "deleted_at": None
         }
@@ -242,15 +244,18 @@ class TestMockPymesync(unittest.TestCase):
     def test_mock_update_user(self):
         parameter_dict = {
             "username": "red-leader",
-            "email": "red-leader@yavin.com"
+            "email": "red-leader@yavin.com",
+            "site_spectator": True
         }
 
         expected_result = {
             "username": "red-leader",
-            "displayname": "Mr. Example",
+            "display_name": "Mr. Example",
             "email": "red-leader@yavin.com",
             "active": True,
-            "admin": False,
+            "site_admin": False,
+            "site_manager": False,
+            "site_spectator": True,
             "created_at": "2015-02-29",
             "deleted_at": None
         }
@@ -480,10 +485,12 @@ class TestMockPymesync(unittest.TestCase):
     def test_mock_get_users_with_username(self):
         expected_result = [{
             "username": "example-user",
-            "displayname": "X. Ample User",
+            "display_name": "X. Ample User",
             "email": "example@example.com",
             "active": True,
-            "admin": False,
+            "site_admin": False,
+            "site_manager": False,
+            "site_spectator": False,
             "created_at": "2015-02-29",
             "deleted_at": None
         }]
@@ -494,37 +501,45 @@ class TestMockPymesync(unittest.TestCase):
         expected_result = [
             {
                 "username": "userone",
-                "displayname": "One Is The Loneliest Number",
+                "display_name": "One Is The Loneliest Number",
                 "email": "exampleone@example.com",
                 "active": True,
-                "admin": False,
+                "site_admin": False,
+                "site_manager": False,
+                "site_spectator": False,
                 "created_at": "2015-02-29",
                 "deleted_at": None
             },
             {
                 "username": "usertwo",
-                "displayname": "Two Can Be As Bad As One",
+                "display_name": "Two Can Be As Bad As One",
                 "email": "exampletwo@example.com",
                 "active": True,
-                "admin": False,
+                "site_admin": False,
+                "site_manager": False,
+                "site_spectator": False,
                 "created_at": "2015-02-29",
                 "deleted_at": None
             },
             {
                 "username": "userthree",
-                "displayname": "Yes It's The Saddest Experience",
+                "display_name": "Yes It's The Saddest Experience",
                 "email": "examplethree@example.com",
                 "active": True,
-                "admin": False,
+                "site_admin": False,
+                "site_manager": False,
+                "site_spectator": False,
                 "created_at": "2015-02-29",
                 "deleted_at": None
             },
             {
                 "username": "userfour",
-                "displayname": "You'll Ever Do",
+                "display_name": "You'll Ever Do",
                 "email": "examplefour@example.com",
                 "active": True,
-                "admin": False,
+                "site_admin": False,
+                "site_manager": False,
+                "site_spectator": False,
                 "created_at": "2015-02-29",
                 "deleted_at": None
             }

--- a/pymesync/tests.py
+++ b/pymesync/tests.py
@@ -243,7 +243,7 @@ class TestPymesync(unittest.TestCase):
         user = {
             "username": "example-user",
             "password": "password",
-            "displayname": "Example User",
+            "display_name": "Example User",
             "email": "example.user@example.com",
         }
 
@@ -271,7 +271,7 @@ class TestPymesync(unittest.TestCase):
         user = {
             "username": "example-user",
             "password": "password",
-            "displayname": "Example User",
+            "display_name": "Example User",
             "email": "example.user@example.com",
         }
 
@@ -299,11 +299,11 @@ class TestPymesync(unittest.TestCase):
     @patch("pymesync.TimeSync._TimeSync__response_to_python")
     def test_create_or_update_update_user_valid_less_fields(self,
                                                             m_resp_python):
-        """Tests TimeSync._TimeSync__create_or_update for update user with one valid
-        parameter"""
+        """Tests TimeSync._TimeSync__create_or_update for update user with one
+        valid parameter"""
         # Parameters to be sent to TimeSync
         user = {
-            "displayname": "Example User",
+            "display_name": "Example User",
         }
 
         # Test baseurl and uuid
@@ -334,7 +334,7 @@ class TestPymesync(unittest.TestCase):
         user = {
             "username": "example-user",
             "password": "password",
-            "displayname": "Example User",
+            "display_name": "Example User",
             "email": "example.user@example.com",
             "bad": "field",
         }
@@ -349,7 +349,7 @@ class TestPymesync(unittest.TestCase):
         required fields"""
         # Parameters to be sent to TimeSync
         user = {
-            "displayname": "Example User",
+            "display_name": "Example User",
             "email": "example.user@example.com",
         }
 
@@ -399,7 +399,7 @@ class TestPymesync(unittest.TestCase):
         user = {
             "username": "example-user",
             "password": "password",
-            "displayname": "Example User",
+            "display_name": "Example User",
             "email": "example.user@example.com",
         }
 
@@ -1791,7 +1791,7 @@ G       methods"""
         user = {
             "username": "example-user",
             "password": "password",
-            "displayname": "Example User",
+            "display_name": "Example User",
             "email": "example.user@example.com",
         }
 
@@ -1806,11 +1806,11 @@ G       methods"""
         user = {
             "username": "example-user",
             "password": "password",
-            "displayname": "Example User",
+            "display_name": "Example User",
             "email": "example.user@example.com",
-            "admin": False,
-            "spectator": False,
-            "manager": True,
+            "site_admin": False,
+            "site_spectator": False,
+            "site_manager": True,
         }
 
         self.ts.create_user(user)
@@ -1823,16 +1823,16 @@ G       methods"""
         user = {
             "username": "example-user",
             "password": "password",
-            "displayname": "Example User",
+            "display_name": "Example User",
             "email": "example.user@example.com",
-            "admin": True,
-            "spectator": False,
-            "manager": True,
+            "site_admin": True,
+            "site_spectator": False,
+            "site_manager": True,
             "active": True,
         }
 
         user_to_test = dict(user)
-        for perm in ["admin", "spectator", "manager", "active"]:
+        for perm in ["site_admin", "site_spectator", "site_manager", "active"]:
             user_to_test = dict(user)
             user_to_test[perm] = "invalid"
             self.assertEquals(self.ts.create_user(user_to_test),
@@ -1846,7 +1846,7 @@ G       methods"""
         user = {
             "username": "example-user",
             "password": "password",
-            "displayname": "Example User",
+            "display_name": "Example User",
             "email": "example.user@example.com",
         }
 

--- a/pymesync/tests.py
+++ b/pymesync/tests.py
@@ -863,249 +863,286 @@ class TestPymesync(unittest.TestCase):
 
         self.assertEquals(self.ts._TimeSync__auth(), auth)
 
-    @patch("pymesync.TimeSync._TimeSync__response_to_python")
-    def test_get_time_for_user(self, m_resp_python):
+    def test_get_time_for_user(self):
         """Tests TimeSync.get_times with username query parameter"""
+        response = resp()
+        response.text = json.dumps(["This should be a list"])
 
         # Mock requests.get
-        requests.get = mock.Mock("requests.get")
+        requests.get = mock.create_autospec(requests.get,
+                                            return_value=response)
 
         url = "{0}/times?user=example-user&token={1}".format(self.ts.baseurl,
                                                              self.ts.token)
 
-        # Send it
-        self.ts.get_times({"user": [self.ts.user]})
-
         # Test that requests.get was called with baseurl and correct parameter
+        self.assertEqual(self.ts.get_times({"user": [self.ts.user]}),
+                         ["This should be a list"])
         requests.get.assert_called_with(url)
 
-    @patch("pymesync.TimeSync._TimeSync__response_to_python")
-    def test_get_time_for_proj(self, m_resp_python):
+    def test_get_time_for_proj(self):
         """Tests TimeSync.get_times with project query parameter"""
+        response = resp()
+        response.text = json.dumps(["This should be a list"])
+
         # Mock requests.get
-        requests.get = mock.Mock("requests.get")
+        requests.get = mock.create_autospec(requests.get,
+                                            return_value=response)
 
         url = "{0}/times?project=gwm&token={1}".format(self.ts.baseurl,
                                                        self.ts.token)
 
-        # Send it
-        self.ts.get_times({"project": ["gwm"]})
-
         # Test that requests.get was called with baseurl and correct parameter
+        self.assertEqual(self.ts.get_times({"project": ["gwm"]}),
+                         ["This should be a list"])
         requests.get.assert_called_with(url)
 
-    @patch("pymesync.TimeSync._TimeSync__response_to_python")
-    def test_get_time_for_activity(self, m_resp_python):
+    def test_get_time_for_activity(self):
         """Tests TimeSync.get_times with activity query parameter"""
+        response = resp()
+        response.text = json.dumps(["This should be a list"])
+
         # Mock requests.get
-        requests.get = mock.Mock("requests.get")
+        requests.get = mock.create_autospec(requests.get,
+                                            return_value=response)
 
         url = "{0}/times?activity=dev&token={1}".format(self.ts.baseurl,
                                                         self.ts.token)
 
-        # Send it
-        self.ts.get_times({"activity": ["dev"]})
-
         # Test that requests.get was called with baseurl and correct parameter
+        self.assertEqual(self.ts.get_times({"activity": ["dev"]}),
+                         ["This should be a list"])
         requests.get.assert_called_with(url)
 
-    @patch("pymesync.TimeSync._TimeSync__response_to_python")
-    def test_get_time_for_start_date(self, m_resp_python):
+    def test_get_time_for_start_date(self):
         """Tests TimeSync.get_times with start date query parameter"""
+        response = resp()
+        response.text = json.dumps(["This should be a list"])
+
         # Mock requests.get
-        requests.get = mock.Mock("requests.get")
+        requests.get = mock.create_autospec(requests.get,
+                                            return_value=response)
 
         url = "{0}/times?start=2015-07-23&token={1}".format(self.ts.baseurl,
                                                             self.ts.token)
 
-        # Send it
-        self.ts.get_times({"start": ["2015-07-23"]})
-
         # Test that requests.get was called with baseurl and correct parameter
+        self.assertEqual(self.ts.get_times({"start": ["2015-07-23"]}),
+                         ["This should be a list"])
         requests.get.assert_called_with(url)
 
-    @patch("pymesync.TimeSync._TimeSync__response_to_python")
-    def test_get_time_for_end_date(self, m_resp_python):
+    def test_get_time_for_end_date(self):
         """Tests TimeSync.get_times with end date query parameter"""
+        response = resp()
+        response.text = json.dumps(["This should be a list"])
+
         # Mock requests.get
-        requests.get = mock.Mock("requests.get")
+        requests.get = mock.create_autospec(requests.get,
+                                            return_value=response)
 
         url = "{0}/times?end=2015-07-23&token={1}".format(self.ts.baseurl,
                                                           self.ts.token)
 
-        # Send it
-        self.ts.get_times({"end": ["2015-07-23"]})
-
         # Test that requests.get was called with baseurl and correct parameter
+        self.assertEqual(self.ts.get_times({"end": ["2015-07-23"]}),
+                         ["This should be a list"])
         requests.get.assert_called_with(url)
 
-    @patch("pymesync.TimeSync._TimeSync__response_to_python")
-    def test_get_time_for_include_revisions(self, m_resp_python):
+    def test_get_time_for_include_revisions(self):
         """Tests TimeSync.get_times with include_revisions query parameter"""
+        response = resp()
+        response.text = json.dumps(["This should be a list"])
+
         # Mock requests.get
-        requests.get = mock.Mock("requests.get")
+        requests.get = mock.create_autospec(requests.get,
+                                            return_value=response)
 
         url = "{0}/times?include_revisions=true&token={1}".format(
             self.ts.baseurl, self.ts.token)
 
-        # Send it
-        self.ts.get_times({"include_revisions": True})
-
         # Test that requests.get was called with baseurl and correct parameter
+        self.assertEqual(self.ts.get_times({"include_revisions": True}),
+                         ["This should be a list"])
         requests.get.assert_called_with(url)
 
-    @patch("pymesync.TimeSync._TimeSync__response_to_python")
-    def test_get_time_for_include_revisions_false(self, m_resp_python):
+    def test_get_time_for_include_revisions_false(self):
         """Tests TimeSync.get_times with include_revisions False query
         parameter"""
+        response = resp()
+        response.text = json.dumps(["This should be a list"])
+
         # Mock requests.get
-        requests.get = mock.Mock("requests.get")
+        requests.get = mock.create_autospec(requests.get,
+                                            return_value=response)
 
         url = "{0}/times?include_revisions=false&token={1}".format(
             self.ts.baseurl, self.ts.token)
 
-        # Send it
-        self.ts.get_times({"include_revisions": False})
-
         # Test that requests.get was called with baseurl and correct parameter
+        self.assertEqual(self.ts.get_times({"include_revisions": False}),
+                         ["This should be a list"])
         requests.get.assert_called_with(url)
 
-    @patch("pymesync.TimeSync._TimeSync__response_to_python")
-    def test_get_time_for_include_deleted(self, m_resp_python):
+    def test_get_time_for_include_deleted(self):
         """Tests TimeSync.get_times with include_deleted query parameter"""
+        response = resp()
+        response.text = json.dumps(["This should be a list"])
+
         # Mock requests.get
-        requests.get = mock.Mock("requests.get")
+        requests.get = mock.create_autospec(requests.get,
+                                            return_value=response)
 
         url = "{0}/times?include_deleted=true&token={1}".format(
             self.ts.baseurl, self.ts.token)
 
-        # Send it
-        self.ts.get_times({"include_deleted": True})
-
         # Test that requests.get was called with baseurl and correct parameter
+        self.assertEqual(self.ts.get_times({"include_deleted": True}),
+                         ["This should be a list"])
         requests.get.assert_called_with(url)
 
-    @patch("pymesync.TimeSync._TimeSync__response_to_python")
-    def test_get_time_for_include_deleted_false(self, m_resp_python):
+    def test_get_time_for_include_deleted_false(self):
         """Tests TimeSync.get_times with include_revisions False query
         parameter"""
+        response = resp()
+        response.text = json.dumps(["This should be a list"])
+
         # Mock requests.get
-        requests.get = mock.Mock("requests.get")
+        requests.get = mock.create_autospec(requests.get,
+                                            return_value=response)
 
         url = "{0}/times?include_deleted=false&token={1}".format(
             self.ts.baseurl, self.ts.token)
 
-        # Send it
-        self.ts.get_times({"include_deleted": False})
-
         # Test that requests.get was called with baseurl and correct parameter
+        self.assertEqual(self.ts.get_times({"include_deleted": False}),
+                         ["This should be a list"])
         requests.get.assert_called_with(url)
 
-    @patch("pymesync.TimeSync._TimeSync__response_to_python")
-    def test_get_time_for_proj_and_activity(self, m_resp_python):
+    def test_get_time_for_proj_and_activity(self):
         """Tests TimeSync.get_times with project and activity query
         parameters"""
+        response = resp()
+        response.text = json.dumps(["This should be a list"])
+
         # Mock requests.get
-        requests.get = mock.Mock("requests.get")
+        requests.get = mock.create_autospec(requests.get,
+                                            return_value=response)
 
         url = "{0}/times?activity=dev&project=gwm&token={1}".format(
             self.ts.baseurl, self.ts.token)
 
-        # Send it
-        self.ts.get_times({"project": ["gwm"], "activity": ["dev"]})
-
         # Test that requests.get was called with baseurl and correct parameters
         # Multiple parameters are sorted alphabetically
+        self.assertEqual(self.ts.get_times({"project": ["gwm"],
+                                            "activity": ["dev"]}),
+                         ["This should be a list"])
         requests.get.assert_called_with(url)
 
-    @patch("pymesync.TimeSync._TimeSync__response_to_python")
-    def test_get_time_for_activity_x3(self, m_resp_python):
+    def test_get_time_for_activity_x3(self):
         """Tests TimeSync.get_times with project and activity query
         parameters"""
+        response = resp()
+        response.text = json.dumps(["This should be a list"])
+
         # Mock requests.get
-        requests.get = mock.Mock("requests.get")
+        requests.get = mock.create_autospec(requests.get,
+                                            return_value=response)
 
         token_string = "&token={}".format(self.ts.token)
 
         url = "{0}/times?activity=dev&activity=rev&activity=hd{1}".format(
             self.ts.baseurl, token_string)
 
-        # Send it
-        self.ts.get_times({"activity": ["dev", "rev", "hd"]})
-
         # Test that requests.get was called with baseurl and correct parameters
         # Multiple parameters are sorted alphabetically
+        self.assertEquals(self.ts.get_times({"activity": ["dev",
+                                                          "rev",
+                                                          "hd"]}),
+                          ["This should be a list"])
         requests.get.assert_called_with(url)
 
-    @patch("pymesync.TimeSync._TimeSync__response_to_python")
-    def test_get_time_with_uuid(self, m_resp_python):
+    def test_get_time_with_uuid(self):
         """Tests TimeSync.get_times with uuid query parameter"""
+        response = resp()
+        response.text = json.dumps(["This should be a list"])
+
         # Mock requests.get
-        requests.get = mock.Mock("requests.get")
+        requests.get = mock.create_autospec(requests.get,
+                                            return_value=response)
 
         url = "{0}/times/sadfasdg432?token={1}".format(self.ts.baseurl,
                                                        self.ts.token)
 
-        # Send it
-        self.ts.get_times({"uuid": "sadfasdg432"})
-
         # Test that requests.get was called with baseurl and correct parameter
+        self.assertEquals(self.ts.get_times({"uuid": "sadfasdg432"}),
+                          ["This should be a list"])
         requests.get.assert_called_with(url)
 
-    @patch("pymesync.TimeSync._TimeSync__response_to_python")
-    def test_get_time_with_uuid_and_activity(self, m_resp_python):
+    def test_get_time_with_uuid_and_activity(self):
         """Tests TimeSync.get_times with uuid and activity query parameters"""
+        response = resp()
+        response.text = json.dumps(["This should be a list"])
+
         # Mock requests.get
-        requests.get = mock.Mock("requests.get")
+        requests.get = mock.create_autospec(requests.get,
+                                            return_value=response)
 
         url = "{0}/times/sadfasdg432?token={1}".format(self.ts.baseurl,
                                                        self.ts.token)
 
-        # Send it
-        self.ts.get_times({"uuid": "sadfasdg432", "activity": ["dev"]})
-
         # Test that requests.get was called with baseurl and correct parameter
+        self.assertEquals(self.ts.get_times({"uuid": "sadfasdg432",
+                                             "activity": ["dev"]}),
+                          ["This should be a list"])
         requests.get.assert_called_with(url)
 
-    @patch("pymesync.TimeSync._TimeSync__response_to_python")
-    def test_get_time_with_uuid_and_include_revisions(self, m_resp_python):
+    def test_get_time_with_uuid_and_include_revisions(self):
         """Tests TimeSync.get_times with uuid and include_revisions query
         parameters"""
+        response = resp()
+        response.text = json.dumps(["This should be a list"])
+
         # Mock requests.get
-        requests.get = mock.Mock("requests.get")
+        requests.get = mock.create_autospec(requests.get,
+                                            return_value=response)
 
         url = "{0}/times/sadfasdg432?include_revisions=true&token={1}".format(
             self.ts.baseurl, self.ts.token)
 
-        # Send it
-        self.ts.get_times({"uuid": "sadfasdg432", "include_revisions": True})
-
         # Test that requests.get was called with baseurl and correct parameter
+        self.assertEquals(self.ts.get_times({"uuid": "sadfasdg432",
+                                             "include_revisions": True}),
+                          ["This should be a list"])
         requests.get.assert_called_with(url)
 
-    @patch("pymesync.TimeSync._TimeSync__response_to_python")
-    def test_get_time_with_uuid_and_include_deleted(self, m_resp_python):
+    def test_get_time_with_uuid_and_include_deleted(self):
         """Tests TimeSync.get_times with uuid and include_deleted query
         parameters"""
+        response = resp()
+        response.text = json.dumps(["This should be a list"])
+
         # Mock requests.get
-        requests.get = mock.Mock("requests.get")
+        requests.get = mock.create_autospec(requests.get,
+                                            return_value=response)
 
         url = "{0}/times/sadfasdg432?include_deleted=true&token={1}".format(
             self.ts.baseurl, self.ts.token)
 
-        # Send it
-        self.ts.get_times({"uuid": "sadfasdg432", "include_deleted": True})
-
         # Test that requests.get was called with baseurl and correct parameter
+        self.assertEquals(self.ts.get_times({"uuid": "sadfasdg432",
+                                             "include_deleted": True}),
+                          ["This should be a list"])
         requests.get.assert_called_with(url)
 
-    @patch("pymesync.TimeSync._TimeSync__response_to_python")
-    def test_get_time_with_uuid_include_deleted_and_revisions(self,
-                                                              m_resp_python):
+    def test_get_time_with_uuid_include_deleted_and_revisions(self):
         """Tests TimeSync.get_times with uuid and include_deleted query
         parameters"""
+        response = resp()
+        response.text = json.dumps(["This should be a list"])
+
         # Mock requests.get
-        requests.get = mock.Mock("requests.get")
+        requests.get = mock.create_autospec(requests.get,
+                                            return_value=response)
 
         # Please forgive me for this. I blame the PEP8 line length rule
         endpoint = "times"
@@ -1115,27 +1152,27 @@ class TestPymesync(unittest.TestCase):
         url = "{0}/{1}/{2}?{3}&{4}".format(self.ts.baseurl, endpoint, uuid,
                                            queries, token)
 
-        # Send it
-        self.ts.get_times({"uuid": "sadfasdg432",
-                           "include_revisions": True,
-                           "include_deleted": True})
-
         # Test that requests.get was called with baseurl and correct parameter
+        self.assertEquals(self.ts.get_times({"uuid": "sadfasdg432",
+                                             "include_revisions": True,
+                                             "include_deleted": True}),
+                          ["This should be a list"])
         requests.get.assert_called_with(url)
 
-    @patch("pymesync.TimeSync._TimeSync__response_to_python")
-    def test_get_all_times(self, m_resp_python):
+    def test_get_all_times(self):
         """Tests TimeSync.get_times with no parameters"""
+        response = resp()
+        response.text = json.dumps(["This should be a list"])
+
         # Mock requests.get
-        requests.get = mock.Mock("requests.get")
+        requests.get = mock.create_autospec(requests.get,
+                                            return_value=response)
 
         url = "{0}/times?token={1}".format(self.ts.baseurl,
                                            self.ts.token)
 
-        # Send it
-        self.ts.get_times()
-
         # Test that requests.get was called with baseurl and correct parameter
+        self.assertEquals(self.ts.get_times(), ["This should be a list"])
         requests.get.assert_called_with(url)
 
     def test_get_times_bad_query(self):
@@ -1144,79 +1181,91 @@ class TestPymesync(unittest.TestCase):
         self.assertEquals(self.ts.get_times({"bad": ["query"]}),
                           [{self.ts.error: "invalid query: bad"}])
 
-    @patch("pymesync.TimeSync._TimeSync__response_to_python")
-    def test_get_projects(self, m_resp_python):
+    def test_get_projects(self):
         """Tests TimeSync.get_projects"""
+        response = resp()
+        response.text = json.dumps(["This should be a list"])
+
         # Mock requests.get
-        requests.get = mock.Mock("requests.get")
+        requests.get = mock.create_autospec(requests.get,
+                                            return_value=response)
 
         url = "{0}/projects?token={1}".format(self.ts.baseurl,
                                               self.ts.token)
 
-        # Send it
-        self.ts.get_projects()
-
         # Test that requests.get was called correctly
+        self.assertEquals(self.ts.get_projects(), ["This should be a list"])
         requests.get.assert_called_with(url)
 
-    @patch("pymesync.TimeSync._TimeSync__response_to_python")
-    def test_get_projects_slug(self, m_resp_python):
+    def test_get_projects_slug(self):
         """Tests TimeSync.get_projects with slug"""
+        response = resp()
+        response.text = json.dumps(["This should be a list"])
+
         # Mock requests.get
-        requests.get = mock.Mock("requests.get")
+        requests.get = mock.create_autospec(requests.get,
+                                            return_value=response)
 
         url = "{0}/projects/gwm?token={1}".format(self.ts.baseurl,
                                                   self.ts.token)
 
-        # Send it
-        self.ts.get_projects({"slug": "gwm"})
-
         # Test that requests.get was called correctly
+        self.assertEquals(self.ts.get_projects({"slug": "gwm"}),
+                          ["This should be a list"])
         requests.get.assert_called_with(url)
 
-    @patch("pymesync.TimeSync._TimeSync__response_to_python")
-    def test_get_projects_include_revisions(self, m_resp_python):
+    def test_get_projects_include_revisions(self):
         """Tests TimeSync.get_projects with include_revisions query"""
+        response = resp()
+        response.text = json.dumps(["This should be a list"])
+
         # Mock requests.get
-        requests.get = mock.Mock("requests.get")
+        requests.get = mock.create_autospec(requests.get,
+                                            return_value=response)
 
         url = "{0}/projects?include_revisions=true&token={1}".format(
             self.ts.baseurl, self.ts.token)
 
-        # Send it
-        self.ts.get_projects({"include_revisions": True})
-
         # Test that requests.get was called correctly
+        self.assertEquals(self.ts.get_projects({"include_revisions": True}),
+                          ["This should be a list"])
         requests.get.assert_called_with(url)
 
-    @patch("pymesync.TimeSync._TimeSync__response_to_python")
-    def test_get_projects_slug_include_revisions(self, m_resp_python):
+    def test_get_projects_slug_include_revisions(self):
         """Tests TimeSync.get_projects with include_revisions query and slug"""
+        response = resp()
+        response.text = json.dumps(["This should be a list"])
+
         # Mock requests.get
-        requests.get = mock.Mock("requests.get")
+        requests.get = mock.create_autospec(requests.get,
+                                            return_value=response)
 
         url = "{0}/projects/gwm?include_revisions=true&token={1}".format(
             self.ts.baseurl, self.ts.token)
 
         # Send it
-        self.ts.get_projects({"slug": "gwm", "include_revisions": True})
 
         # Test that requests.get was called correctly
+        self.assertEquals(self.ts.get_projects({"slug": "gwm",
+                                                "include_revisions": True}),
+                          ["This should be a list"])
         requests.get.assert_called_with(url)
 
-    @patch("pymesync.TimeSync._TimeSync__response_to_python")
-    def test_get_projects_include_deleted(self, m_resp_python):
+    def test_get_projects_include_deleted(self):
         """Tests TimeSync.get_projects with include_deleted query"""
+        response = resp()
+        response.text = json.dumps(["This should be a list"])
+
         # Mock requests.get
-        requests.get = mock.Mock("requests.get")
+        requests.get = mock.create_autospec(requests.get,
+                                            return_value=response)
 
         url = "{0}/projects?include_deleted=true&token={1}".format(
             self.ts.baseurl, self.ts.token)
 
-        # Send it
-        self.ts.get_projects({"include_deleted": True})
-
         # Test that requests.get was called correctly
+        self.assertEquals(self.ts.get_projects({"include_deleted": True}),
+                          ["This should be a list"])
         requests.get.assert_called_with(url)
 
     def test_get_projects_include_deleted_with_slug(self):
@@ -1232,98 +1281,111 @@ class TestPymesync(unittest.TestCase):
                           [{self.ts.error:
                            "invalid combination: slug and include_deleted"}])
 
-    @patch("pymesync.TimeSync._TimeSync__response_to_python")
-    def test_get_projects_include_deleted_include_revisions(self,
-                                                            m_resp_python):
+    def test_get_projects_include_deleted_include_revisions(self):
         """Tests TimeSync.get_projects with include_revisions and
         include_deleted queries"""
+        response = resp()
+        response.text = json.dumps(["This should be a list"])
+
         # Mock requests.get
-        requests.get = mock.Mock("requests.get")
+        requests.get = mock.create_autospec(requests.get,
+                                            return_value=response)
 
         token_string = "&token={}".format(self.ts.token)
         endpoint = "/projects"
         url = "{0}{1}?include_deleted=true&include_revisions=true{2}".format(
             self.ts.baseurl, endpoint, token_string)
 
-        # Send it
-        self.ts.get_projects({"include_revisions": True,
-                              "include_deleted": True})
-
         # Test that requests.get was called with correct parameters
+        self.assertEquals(self.ts.get_projects({"include_revisions": True,
+                                                "include_deleted": True}),
+                          ["This should be a list"])
         requests.get.assert_called_with(url)
 
-    @patch("pymesync.TimeSync._TimeSync__response_to_python")
-    def test_get_activities(self, m_resp_python):
+    def test_get_activities(self):
         """Tests TimeSync.get_activities"""
+        response = resp()
+        response.text = json.dumps(["This should be a list"])
+
         # Mock requests.get
-        requests.get = mock.Mock("requests.get")
+        requests.get = mock.create_autospec(requests.get,
+                                            return_value=response)
 
         url = "{0}/activities?token={1}".format(self.ts.baseurl, self.ts.token)
 
-        # Send it
-        self.ts.get_activities()
-
         # Test that requests.get was called correctly
+        self.assertEquals(self.ts.get_activities(), ["This should be a list"])
         requests.get.assert_called_with(url)
 
-    @patch("pymesync.TimeSync._TimeSync__response_to_python")
-    def test_get_activities_slug(self, m_resp_python):
+    def test_get_activities_slug(self):
         """Tests TimeSync.get_activities with slug"""
+        response = resp()
+        response.text = json.dumps(["This should be a list"])
+
         # Mock requests.get
-        requests.get = mock.Mock("requests.get")
+        requests.get = mock.create_autospec(requests.get,
+                                            return_value=response)
 
         url = "{0}/activities/code?token={1}".format(self.ts.baseurl,
                                                      self.ts.token)
 
-        # Send it
-        self.ts.get_activities({"slug": "code"})
-
         # Test that requests.get was called correctly
+        self.assertEquals(self.ts.get_activities({"slug": "code"}),
+                          ["This should be a list"])
         requests.get.assert_called_with(url)
 
-    @patch("pymesync.TimeSync._TimeSync__response_to_python")
-    def test_get_activities_include_revisions(self, m_resp_python):
+    def test_get_activities_include_revisions(self):
         """Tests TimeSync.get_activities with include_revisions query"""
+        response = resp()
+        response.text = json.dumps(["This should be a list"])
+
         # Mock requests.get
-        requests.get = mock.Mock("requests.get")
+        requests.get = mock.create_autospec(requests.get,
+                                            return_value=response)
 
         url = "{0}/activities?include_revisions=true&token={1}".format(
             self.ts.baseurl, self.ts.token)
 
-        # Send it
-        self.ts.get_activities({"include_revisions": True})
-
         # Test that requests.get was called correctly
+        self.assertEquals(self.ts.get_activities({"include_revisions": True}),
+                          ["This should be a list"])
         requests.get.assert_called_with(url)
 
-    @patch("pymesync.TimeSync._TimeSync__response_to_python")
-    def test_get_activities_slug_include_revisions(self, m_resp_python):
+    def test_get_activities_slug_include_revisions(self):
         """Tests TimeSync.get_projects with include_revisions query and slug"""
+        response = resp()
+        response.text = json.dumps(["This should be a list"])
+
         # Mock requests.get
-        requests.get = mock.Mock("requests.get")
+        requests.get = mock.create_autospec(requests.get,
+                                            return_value=response)
 
         url = "{0}/activities/code?include_revisions=true&token={1}".format(
             self.ts.baseurl, self.ts.token)
 
-        # Send it
-        self.ts.get_activities({"slug": "code", "include_revisions": True})
-
         # Test that requests.get was called correctly
+        self.assertEquals(self.ts.get_activities({"slug": "code",
+                                                  "include_revisions": True}),
+                          ["This should be a list"])
         requests.get.assert_called_with(url)
 
-    @patch("pymesync.TimeSync._TimeSync__response_to_python")
-    def test_get_activities_include_deleted(self, m_resp_python):
+    def test_get_activities_include_deleted(self):
         """Tests TimeSync.get_activities with include_deleted query"""
+        response = resp()
+        response.text = json.dumps(["This should be a list"])
+
         # Mock requests.get
-        requests.get = mock.Mock("requests.get")
+        requests.get = mock.create_autospec(requests.get,
+                                            return_value=response)
 
         url = "{0}/activities?include_deleted=true&token={1}".format(
             self.ts.baseurl, self.ts.token)
 
         # Send it
-        self.ts.get_activities({"include_deleted": True})
 
         # Test that requests.get was called correctly
+        self.assertEquals(self.ts.get_activities({"include_deleted": True}),
+                          ["This should be a list"])
         requests.get.assert_called_with(url)
 
     def test_get_activities_include_deleted_with_slug(self):
@@ -1339,13 +1401,15 @@ class TestPymesync(unittest.TestCase):
                           [{self.ts.error:
                            "invalid combination: slug and include_deleted"}])
 
-    @patch("pymesync.TimeSync._TimeSync__response_to_python")
-    def test_get_activities_include_deleted_include_revisions(self,
-                                                              m_resp_python):
+    def test_get_activities_include_deleted_include_revisions(self):
         """Tests TimeSync.get_activities with include_revisions and
         include_deleted queries"""
+        response = resp()
+        response.text = json.dumps(["This should be a list"])
+
         # Mock requests.get
-        requests.get = mock.Mock("requests.get")
+        requests.get = mock.create_autospec(requests.get,
+                                            return_value=response)
 
         token_string = "&token={}".format(self.ts.token)
         endpoint = "/activities"
@@ -1384,11 +1448,14 @@ class TestPymesync(unittest.TestCase):
                             "Not authenticated with TimeSync, "
                             "call self.authenticate() first"}])
 
-    @patch("pymesync.TimeSync._TimeSync__response_to_python")
-    def test_get_users(self, m_resp_python):
+    def test_get_users(self):
         """Tests TimeSync.get_users"""
+        response = resp()
+        response.text = json.dumps(["This should be a list"])
+
         # Mock requests.get
-        requests.get = mock.Mock("requests.get")
+        requests.get = mock.create_autospec(requests.get,
+                                            return_value=response)
 
         url = "{0}/users?token={1}".format(self.ts.baseurl, self.ts.token)
 
@@ -1398,11 +1465,14 @@ class TestPymesync(unittest.TestCase):
         # Test that requests.get was called correctly
         requests.get.assert_called_with(url)
 
-    @patch("pymesync.TimeSync._TimeSync__response_to_python")
-    def test_get_users_username(self, m_resp_python):
+    def test_get_users_username(self):
         """Tests TimeSync.get_users with username"""
+        response = resp()
+        response.text = json.dumps(["This should be a list"])
+
         # Mock requests.get
-        requests.get = mock.Mock("requests.get")
+        requests.get = mock.create_autospec(requests.get,
+                                            return_value=response)
 
         url = "{0}/users/{1}?token={2}".format(self.ts.baseurl,
                                                "example-user",


### PR DESCRIPTION
Fixes #116 

- Fixes bug where optional user params were incorrect, causing `create_user` and `update_user` methods to fail with timesync errors.
- Fixes bug where get_* methods were returning doubly-nested lists