### PR TITLE
Remove trailing "/" from baseurl

### DIFF
--- a/pymesync/pymesync.py
+++ b/pymesync/pymesync.py
@@ -35,7 +35,7 @@ import bcrypt
 class TimeSync(object):
 
     def __init__(self, baseurl, token=None, test=False):
-        self.baseurl = baseurl
+        self.baseurl = baseurl[:-1] if baseurl.endswith("/") else baseurl
         self.user = None
         self.password = None
         self.auth_type = None

--- a/pymesync/tests.py
+++ b/pymesync/tests.py
@@ -2369,6 +2369,11 @@ G       methods"""
                           {self.ts.error: "Missing project slug, please "
                                           "include in method call"})
 
+    def test_baseurl_with_trailing_slash(self):
+        """Test that the trailing slash in the baseurl is removed"""
+        self.ts = pymesync.TimeSync("http://ts.example.com/v1/")
+        self.assertEquals(self.ts.baseurl, "http://ts.example.com/v1")
+
 if __name__ == "__main__":
     # Save these for resetting mocked methods
     actual_post = requests.post

--- a/pymesync/tests.py
+++ b/pymesync/tests.py
@@ -2374,6 +2374,11 @@ G       methods"""
         self.ts = pymesync.TimeSync("http://ts.example.com/v1/")
         self.assertEquals(self.ts.baseurl, "http://ts.example.com/v1")
 
+    def test_baseurl_without_trailing_slash(self):
+        """Test that the trailing slash in the baseurl is removed"""
+        self.ts = pymesync.TimeSync("http://ts.example.com/v1")
+        self.assertEquals(self.ts.baseurl, "http://ts.example.com/v1")
+
 if __name__ == "__main__":
     # Save these for resetting mocked methods
     actual_post = requests.post


### PR DESCRIPTION
Fixes #123
This allows pymesync to append the "/" itself when accessing TimeSync endpoints.
The user can choose whether or not to include the trailing "/" in the baseurl.