### PR TITLE
Make time object activities an optional field

### DIFF
--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -249,8 +249,6 @@ TimeSync.\ **create_time(time)**
     * ``"project"`` - slug of project worked on
     * ``"user"`` - username of user that did the work, must match ``user``
       specified in instantiation
-    * ``"activities"`` - list of slugs identifying the activies worked on for
-      this time entry
     * ``"date_worked"`` - date worked for this time entry in the form
       ``"yyyy-mm-dd"``
 
@@ -258,6 +256,10 @@ TimeSync.\ **create_time(time)**
 
     * ``"notes"`` - optional notes about this time entry
     * ``"issue_uri"`` - optional uri to issue worked on
+    * ``"activities"`` - list of slugs identifying the activies worked on for
+      this time entry. If this is not provided and the ``project`` submitted
+      has no ``default_activity`` defined by TimeSync, an error will be
+      returned informing the user to include an activity.
 
     Example usage:
 

--- a/pymesync/pymesync.py
+++ b/pymesync/pymesync.py
@@ -46,14 +46,13 @@ class TimeSync(object):
                                   "start", "end", "include_revisions",
                                   "include_deleted", "uuid"]
         self.required_params = {
-            "time":     ["duration", "project", "user",
-                         "activities", "date_worked"],
+            "time":     ["duration", "project", "user", "date_worked"],
             "project":  ["name", "slugs"],
             "activity": ["name", "slug"],
             "user":     ["username", "password"],
         }
         self.optional_params = {
-            "time":     ["notes", "issue_uri"],
+            "time":     ["notes", "issue_uri", "activities"],
             "project":  ["uri", "users", "default_activity"],
             "activity": [],
             "user":     ["display_name", "email", "site_admin",

--- a/pymesync/tests.py
+++ b/pymesync/tests.py
@@ -166,7 +166,6 @@ class TestPymesync(unittest.TestCase):
         missing required fields"""
         # Parameters to be sent to TimeSync
         time = {
-            "duration": 12,
             "user": "example-user",
             "notes": "Worked on docs",
             "issue_uri": "https://github.com/",
@@ -177,7 +176,7 @@ class TestPymesync(unittest.TestCase):
                                                               "time", "times"),
                           {self.ts.error:
                            "time object: missing required field(s): "
-                           "project, activities"})
+                           "duration, project"})
 
     def test_create_or_update_create_time_each_required_missing(self):
         """Tests TimeSync._TimeSync__create_or_update to create time with
@@ -187,7 +186,6 @@ class TestPymesync(unittest.TestCase):
             "duration": 12,
             "project": "ganeti-web-manager",
             "user": "example-user",
-            "activities": ["documenting"],
             "date_worked": "2014-04-17",
         }
 


### PR DESCRIPTION
Fixes #125
Allows a time to be created without an activity when a default
activity is defined by TimeSync.