### PR TITLE
Change str() method call to unicode()

### DIFF
--- a/pymesync/pymesync.py
+++ b/pymesync/pymesync.py
@@ -735,7 +735,7 @@ class TimeSync(object):
         # and we got a ValueError, we know we are having trouble connecting to
         # TimeSync because we are not getting a return from TimeSync.
         try:
-            python_object = json.loads(str(response.text))
+            python_object = json.loads(unicode(response.text))
         except ValueError:
             # If we get a ValueError, response.text isn't a JSON object, and
             # therefore didn't come from a TimeSync connection.


### PR DESCRIPTION
Fixes #127 . str() fails when passed unicode.

Manual testing displayed below:

```
mrsj@pewter:~/work/pymesync/pymesync [mrsj/bugfix-unicode] (venv) » python
Python 2.7.9 (default, Mar  1 2015, 12:57:24) 
[GCC 4.9.2] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> import pymesync
>>> ts = pymesync.TimeSync("<baseurl>")
>>> ts.authenticate("admin", "<password>", "password")
{u'token': u'YouDOnTNeEEdtoSeeAlLThis===='}
>>> ts.get_activities()
{'pymesync error': 'connection to TimeSync failed at baseurl http://timesync-staging.osuosl.org/v1 - response status was 200'}
>>> 
KeyboardInterrupt
>>> 
mrsj@pewter:~/work/pymesync/pymesync [mrsj/bugfix-unicode] (venv) » git stash apply
On branch mrsj/bugfix-unicode
Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git checkout -- <file>..." to discard changes in working directory)

	modified:   pymesync.py

no changes added to commit (use "git add" and/or "git commit -a")
mrsj@pewter:~/work/pymesync/pymesync [mrsj/bugfix-unicode] (venv) » python
Python 2.7.9 (default, Mar  1 2015, 12:57:24) 
[GCC 4.9.2] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> import pymesync
>>> ts = pymesync.TimeSync("<baseurl>")
>>> ts.authenticate("admin", "<password>", "password")
{u'token': u'YouDOnTNeEEdtoSeeAlLThis=='}
>>> ts.get_activities()
[{u'uuid': u'aea9825d-ded6-444d-be7e-6757ce621807', u'created_at': u'2016-03-22', u'updated_at': None, u'name': u'Documentation', u'deleted_at': None, u'slug': u'docs', u'revision': 1}, {u'uuid': u'46cf4220-cd8f-4bb4-bc93-a54cc729172c', u'created_at': u'2016-03-29', u'updated_at': None, u'name': u'Meetings', u'deleted_at': None, u'slug': u'meet', u'revision': 1}, {u'uuid': u'fef5f73e-6a5b-4eb3-852f-6f4bfb0c2868', u'created_at': u'2016-03-30', u'updated_at': u'2016-04-05', u'name': u'Testing', u'deleted_at': None, u'slug': u'docs', u'revision': 2}, {u'uuid': u'b42aec92-364b-4a28-993d-839e02ded501', u'created_at': u'2016-04-05', u'updated_at': None, u'name': u'Testing', u'deleted_at': None, u'slug': u'testing', u'revision': 1}, {u'uuid': u'2a1477ad-74e8-4d6a-a8fe-de07ea2d05a3', u'created_at': u'2016-03-22', u'updated_at': u'2016-04-05', u'name': u'\xa0', u'deleted_at': None, u'slug': u'dev', u'revision': 2}]
>>> 

```