### PR TITLE
Split token on each '.' when parsing for expiration

### DIFF
--- a/pymesync/pymesync.py
+++ b/pymesync/pymesync.py
@@ -634,7 +634,7 @@ class TimeSync(object):
         # Decode the token, then get the second dict (payload) from the
         # resulting string. The payload contains the expiration time.
         try:
-            decoded_payload = base64.b64decode(self.token.split(".", 1)[1])
+            decoded_payload = base64.b64decode(self.token.split(".")[1])
         except:
             return {self.error: "improperly encoded token"}
 

--- a/pymesync/tests.py
+++ b/pymesync/tests.py
@@ -2205,7 +2205,7 @@ G       methods"""
                          "4N30=.QP2FbiY3I6e2eN436hpdjoBFbW9NdrRUHbkJ+wr9GK9mMW"
                          "7/oC/oKnutCwwzMCwjzEx6hlxnGo6/LiGyPBcm3w==")
 
-        decoded_payload = base64.b64decode(self.ts.token.split(".", 1)[1])
+        decoded_payload = base64.b64decode(self.ts.token.split(".")[1])
         exp_int = ast.literal_eval(decoded_payload)['exp'] / 1000
         exp_datetime = datetime.datetime.fromtimestamp(exp_int)
 


### PR DESCRIPTION
Bugfix. We were trying to parse the entire token, including the
randomly generated chars at the end.

Fixes #135 