### PR TITLE
Add Github PR Template

### DIFF
--- a/pymesync/.github/PULL_REQUEST_TEMPLATE.md
+++ b/pymesync/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,31 @@
+<!--
+  This is a guideline for what a PR should look like.
+  Feel free to modify it to fit your specific needs.
+
+  Please list the issue this fixes in the PR
+-->
+fixes issue #xx
+
+## Changes in this PR.
+<!--
+  Please include a list of all things this PR will accomplish
+  Use the checkbox syntax to show what is done and what is yet to be completed.
+  This gives context to the diff.
+-->
+
+- [X] Foo
+- [X] Bar
+- [ ] Baz
+
+## Testing this PR.
+<!--
+  Please include a list of explicit instructions for testing this PR.
+  If the instructions are 'run `make test`' say that,
+  If they are more complicated be thorough.
+-->
+
+1. Do X.
+2. Do Y.
+3. See Z.
+
+@osuosl/devs


### PR DESCRIPTION
I know, I know. I'm pushing for this everywhere. It is awesome though.

Good: Forces developers to write descriptive PRs with testing instructions. This is helpful for reviewers who aren't familiar with the code base.

Bad: Nothing.