### PR TITLE
Convert "slugs" to "slug" inside mock pymesync

### DIFF
--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -529,9 +529,9 @@ TimeSync.\ **get_activities(query_parameters=None)**
     .. code-block:: python
 
       >>> ts.get_activities()
-      [{u'uuid': u'adf036f5-3d49-4a84-bef9-062b46380bbf', u'created_at': u'2014-04-17', u'updated_at': None, u'name': u'Documentation', u'deleted_at': None, u'slugs': [u'docs'], u'revision': 5}, {u'uuid': u'adf036f5-3d49-bbbb-rrrr-062b46380bbf', u'created_at': u'2014-04-17', u'updated_at': None, u'name': u'Coding', u'deleted_at': None, u'slugs': [u'code', u'dev'], u'revision': 1}, {u'uuid': u'adf036f5-3d49-cccc-ssss-062b46380bbf', u'created_at': u'2014-04-17', u'updated_at': None, u'name': u'Planning', u'deleted_at': None, u'slugs': [u'plan', u'prep'], u'revision': 1}]
+      [{u'uuid': u'adf036f5-3d49-4a84-bef9-062b46380bbf', u'created_at': u'2014-04-17', u'updated_at': None, u'name': u'Documentation', u'deleted_at': None, u'slug': u'docs', u'revision': 5}, {u'uuid': u'adf036f5-3d49-bbbb-rrrr-062b46380bbf', u'created_at': u'2014-04-17', u'updated_at': None, u'name': u'Coding', u'deleted_at': None, u'slug': u'dev', u'revision': 1}, {u'uuid': u'adf036f5-3d49-cccc-ssss-062b46380bbf', u'created_at': u'2014-04-17', u'updated_at': None, u'name': u'Planning', u'deleted_at': None, u'slug': u'plan', u'revision': 1}]
       >>> ts.get_activities({"slug": "docs"})
-      [{u'uuid': u'adf036f5-3d49-4a84-bef9-062b46380bbf', u'created_at': u'2014-04-17', u'updated_at': None, u'name': u'Documentation', u'deleted_at': None, u'slugs': [u'docs'], u'revision': 5}]
+      [{u'uuid': u'adf036f5-3d49-4a84-bef9-062b46380bbf', u'created_at': u'2014-04-17', u'updated_at': None, u'name': u'Documentation', u'deleted_at': None, u'slug': u'docs', u'revision': 5}]
       >>>
 
     .. warning::

--- a/pymesync/mock_pymesync.py
+++ b/pymesync/mock_pymesync.py
@@ -289,7 +289,7 @@ def get_activities(slug):
     p_list = [
         {
             "name": "Documentation",
-            "slugs": [slug if slug else "docs"],
+            "slug": slug if slug else "docs",
             "uuid": "adf036f5-3d49-4a84-bef9-062b46380bbf",
             "revision": 5,
             "created_at": "2014-04-17",
@@ -301,7 +301,7 @@ def get_activities(slug):
         p_list.append(
             {
                 "name": "Coding",
-                "slugs": ["code", "dev"],
+                "slug": "dev",
                 "uuid": "adf036f5-3d49-bbbb-rrrr-062b46380bbf",
                 "revision": 1,
                 "created_at": "2014-04-17",
@@ -313,7 +313,7 @@ def get_activities(slug):
         p_list.append(
             {
                 "name": "Planning",
-                "slugs": ["plan", "prep"],
+                "slug": "plan",
                 "uuid": "adf036f5-3d49-cccc-ssss-062b46380bbf",
                 "revision": 1,
                 "created_at": "2014-04-17",

--- a/pymesync/test_mock_pymesync.py
+++ b/pymesync/test_mock_pymesync.py
@@ -438,7 +438,7 @@ class TestMockPymesync(unittest.TestCase):
     def test_mock_get_activities_with_slug(self):
         expected_result = [{
             "name": "Documentation",
-            "slugs": ["docudocs"],
+            "slug": "docudocs",
             "uuid": "adf036f5-3d49-4a84-bef9-062b46380bbf",
             "revision": 5,
             "created_at": "2014-04-17",
@@ -453,7 +453,7 @@ class TestMockPymesync(unittest.TestCase):
         expected_result = [
             {
                 "name": "Documentation",
-                "slugs": ["docs"],
+                "slug": "docs",
                 "uuid": "adf036f5-3d49-4a84-bef9-062b46380bbf",
                 "revision": 5,
                 "created_at": "2014-04-17",
@@ -462,7 +462,7 @@ class TestMockPymesync(unittest.TestCase):
             },
             {
                 "name": "Coding",
-                "slugs": ["code", "dev"],
+                "slug": "dev",
                 "uuid": "adf036f5-3d49-bbbb-rrrr-062b46380bbf",
                 "revision": 1,
                 "created_at": "2014-04-17",
@@ -471,7 +471,7 @@ class TestMockPymesync(unittest.TestCase):
             },
             {
                 "name": "Planning",
-                "slugs": ["plan", "prep"],
+                "slug": "plan",
                 "uuid": "adf036f5-3d49-cccc-ssss-062b46380bbf",
                 "revision": 1,
                 "created_at": "2014-04-17",


### PR DESCRIPTION
<!--
  This is a guideline for what a PR should look like.
  Feel free to modify it to fit your specific needs.

  Please list the issue this fixes in the PR
-->
fixes issue #147 

## Changes in this PR.
<!--
  Please include a list of all things this PR will accomplish
  Use the checkbox syntax to show what is done and what is yet to be completed.
  This gives context to the diff.
-->

- [X] Update documentation to reflect get_activities returning a single slug instead of a list of slugs
- [X] Fix mock_pymesync.py to reflect the correct return value of get_activities (with each activity having a single slug)

## Testing this PR.
<!--
  Please include a list of explicit instructions for testing this PR.
  If the instructions are 'run `make test`' say that,
  If they are more complicated be thorough.
-->

1. Run `make test`

@osuosl/devs
