### PR TITLE
Fixed Unicode support for create/update user

### DIFF
--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -529,9 +529,9 @@ TimeSync.\ **get_activities(query_parameters=None)**
     .. code-block:: python
 
       >>> ts.get_activities()
-      [{u'uuid': u'adf036f5-3d49-4a84-bef9-062b46380bbf', u'created_at': u'2014-04-17', u'updated_at': None, u'name': u'Documentation', u'deleted_at': None, u'slugs': [u'docs'], u'revision': 5}, {u'uuid': u'adf036f5-3d49-bbbb-rrrr-062b46380bbf', u'created_at': u'2014-04-17', u'updated_at': None, u'name': u'Coding', u'deleted_at': None, u'slugs': [u'code', u'dev'], u'revision': 1}, {u'uuid': u'adf036f5-3d49-cccc-ssss-062b46380bbf', u'created_at': u'2014-04-17', u'updated_at': None, u'name': u'Planning', u'deleted_at': None, u'slugs': [u'plan', u'prep'], u'revision': 1}]
+      [{u'uuid': u'adf036f5-3d49-4a84-bef9-062b46380bbf', u'created_at': u'2014-04-17', u'updated_at': None, u'name': u'Documentation', u'deleted_at': None, u'slug': u'docs', u'revision': 5}, {u'uuid': u'adf036f5-3d49-bbbb-rrrr-062b46380bbf', u'created_at': u'2014-04-17', u'updated_at': None, u'name': u'Coding', u'deleted_at': None, u'slug': u'dev', u'revision': 1}, {u'uuid': u'adf036f5-3d49-cccc-ssss-062b46380bbf', u'created_at': u'2014-04-17', u'updated_at': None, u'name': u'Planning', u'deleted_at': None, u'slug': u'plan', u'revision': 1}]
       >>> ts.get_activities({"slug": "docs"})
-      [{u'uuid': u'adf036f5-3d49-4a84-bef9-062b46380bbf', u'created_at': u'2014-04-17', u'updated_at': None, u'name': u'Documentation', u'deleted_at': None, u'slugs': [u'docs'], u'revision': 5}]
+      [{u'uuid': u'adf036f5-3d49-4a84-bef9-062b46380bbf', u'created_at': u'2014-04-17', u'updated_at': None, u'name': u'Documentation', u'deleted_at': None, u'slug': u'docs', u'revision': 5}]
       >>>
 
     .. warning::

--- a/pymesync/mock_pymesync.py
+++ b/pymesync/mock_pymesync.py
@@ -289,7 +289,7 @@ def get_activities(slug):
     p_list = [
         {
             "name": "Documentation",
-            "slugs": [slug if slug else "docs"],
+            "slug": slug if slug else "docs",
             "uuid": "adf036f5-3d49-4a84-bef9-062b46380bbf",
             "revision": 5,
             "created_at": "2014-04-17",
@@ -301,7 +301,7 @@ def get_activities(slug):
         p_list.append(
             {
                 "name": "Coding",
-                "slugs": ["code", "dev"],
+                "slug": "dev",
                 "uuid": "adf036f5-3d49-bbbb-rrrr-062b46380bbf",
                 "revision": 1,
                 "created_at": "2014-04-17",
@@ -313,7 +313,7 @@ def get_activities(slug):
         p_list.append(
             {
                 "name": "Planning",
-                "slugs": ["plan", "prep"],
+                "slug": "plan",
                 "uuid": "adf036f5-3d49-cccc-ssss-062b46380bbf",
                 "revision": 1,
                 "created_at": "2014-04-17",

--- a/pymesync/pymesync.py
+++ b/pymesync/pymesync.py
@@ -263,12 +263,13 @@ class TimeSync(object):
         # Don't error out here so that internal methods can catch all missing
         # fields later on and return a more meaningful error if necessary.
         if "password" in user:
-            # Hash the password
+            # If the password is a unicode object, encode it first
             if isinstance(user["password"], unicode):
                 password = user["password"].encode("utf-8")
             else:
                 password = user["password"]
 
+            # Hash the password
             hashed = bcrypt.hashpw(password, bcrypt.gensalt(prefix=b"2a",
                                                             rounds=10))
             user["password"] = hashed
@@ -298,12 +299,13 @@ class TimeSync(object):
         # Don't error out here so that internal methods can catch all missing
         # fields later on and return a more meaningful error if necessary.
         if "password" in user:
-            # Hash the password
+            # If the password is a unicode object, encode it first
             if isinstance(user["password"], unicode):
                 password = user["password"].encode("utf-8")
             else:
                 password = user["password"]
 
+            # Hash the password
             hashed = bcrypt.hashpw(password, bcrypt.gensalt(prefix=b"2a",
                                                             rounds=10))
             user["password"] = hashed

--- a/pymesync/pymesync.py
+++ b/pymesync/pymesync.py
@@ -264,7 +264,11 @@ class TimeSync(object):
         # fields later on and return a more meaningful error if necessary.
         if "password" in user:
             # Hash the password
-            password = user["password"]
+            if isinstance(user["password"], unicode):
+                password = user["password"].encode("utf-8")
+            else:
+                password = user["password"]
+
             hashed = bcrypt.hashpw(password, bcrypt.gensalt(prefix=b"2a",
                                                             rounds=10))
             user["password"] = hashed
@@ -295,7 +299,11 @@ class TimeSync(object):
         # fields later on and return a more meaningful error if necessary.
         if "password" in user:
             # Hash the password
-            password = user["password"]
+            if isinstance(user["password"], unicode):
+                password = user["password"].encode("utf-8")
+            else:
+                password = user["password"]
+
             hashed = bcrypt.hashpw(password, bcrypt.gensalt(prefix=b"2a",
                                                             rounds=10))
             user["password"] = hashed

--- a/pymesync/pymesync.py
+++ b/pymesync/pymesync.py
@@ -259,20 +259,7 @@ class TimeSync(object):
                 return {self.error: "user object: "
                         "{} must be True or False".format(perm)}
 
-        # Only hash password if it is present
-        # Don't error out here so that internal methods can catch all missing
-        # fields later on and return a more meaningful error if necessary.
-        if "password" in user:
-            # If the password is a unicode object, encode it first
-            if isinstance(user["password"], unicode):
-                password = user["password"].encode("utf-8")
-            else:
-                password = user["password"]
-
-            # Hash the password
-            hashed = bcrypt.hashpw(password, bcrypt.gensalt(prefix=b"2a",
-                                                            rounds=10))
-            user["password"] = hashed
+        self.__hash_user_password(user)
 
         return self.__create_or_update(user, None, "user", "users")
 
@@ -295,20 +282,7 @@ class TimeSync(object):
                 return {self.error: "user object: "
                         "{} must be True or False".format(perm)}
 
-        # Only hash password if it is present
-        # Don't error out here so that internal methods can catch all missing
-        # fields later on and return a more meaningful error if necessary.
-        if "password" in user:
-            # If the password is a unicode object, encode it first
-            if isinstance(user["password"], unicode):
-                password = user["password"].encode("utf-8")
-            else:
-                password = user["password"]
-
-            # Hash the password
-            hashed = bcrypt.hashpw(password, bcrypt.gensalt(prefix=b"2a",
-                                                            rounds=10))
-            user["password"] = hashed
+        self.__hash_user_password(user)
 
         return self.__create_or_update(user, username, "user", "users", False)
 
@@ -938,6 +912,24 @@ class TimeSync(object):
         except:
             error_msg = [{self.error: "time object: invalid duration string"}]
             return error_msg
+
+    def __hash_user_password(self, user):
+        """Hashes the password field in a user object. If the password is
+        Unicode, encode it to UTF-8 first"""
+        # Only hash password if it is present
+        # Don't error out here so that internal methods can catch all missing
+        # fields later on and return a more meaningful error if necessary.
+        if "password" in user:
+            # If the password is a unicode object, encode it first
+            if isinstance(user["password"], unicode):
+                password = user["password"].encode("utf-8")
+            else:
+                password = user["password"]
+
+            # Hash the password
+            hashed = bcrypt.hashpw(password, bcrypt.gensalt(prefix=b"2a",
+                                                            rounds=10))
+            user["password"] = hashed
 
     def __delete_object(self, endpoint, identifier):
         """Deletes object at ``endpoint`` identified by ``identifier``"""

--- a/pymesync/pymesync.py
+++ b/pymesync/pymesync.py
@@ -164,16 +164,17 @@ class TimeSync(object):
         to TimeSync.
         ``uuid`` contains the uuid for a time entry to update.
         """
-        if time['duration'] < 0:
-            return {self.error: "time object: duration cannot be negative"}
+        if 'duration' in time:
+            if time['duration'] < 0:
+                return {self.error: "time object: duration cannot be negative"}
 
-        if not isinstance(time['duration'], int):
-            duration = self.__duration_to_seconds(time['duration'])
-            time['duration'] = duration
-
-            # Duration at this point contains an error_msg if it's not an int
             if not isinstance(time['duration'], int):
-                return duration
+                duration = self.__duration_to_seconds(time['duration'])
+                time['duration'] = duration
+
+                # Duration at this point contains an error_msg if not an int
+                if not isinstance(time['duration'], int):
+                    return duration
 
         return self.__create_or_update(time, uuid, "time", "times", False)
 

--- a/pymesync/test_mock_pymesync.py
+++ b/pymesync/test_mock_pymesync.py
@@ -438,7 +438,7 @@ class TestMockPymesync(unittest.TestCase):
     def test_mock_get_activities_with_slug(self):
         expected_result = [{
             "name": "Documentation",
-            "slugs": ["docudocs"],
+            "slug": "docudocs",
             "uuid": "adf036f5-3d49-4a84-bef9-062b46380bbf",
             "revision": 5,
             "created_at": "2014-04-17",
@@ -453,7 +453,7 @@ class TestMockPymesync(unittest.TestCase):
         expected_result = [
             {
                 "name": "Documentation",
-                "slugs": ["docs"],
+                "slug": "docs",
                 "uuid": "adf036f5-3d49-4a84-bef9-062b46380bbf",
                 "revision": 5,
                 "created_at": "2014-04-17",
@@ -462,7 +462,7 @@ class TestMockPymesync(unittest.TestCase):
             },
             {
                 "name": "Coding",
-                "slugs": ["code", "dev"],
+                "slug": "dev",
                 "uuid": "adf036f5-3d49-bbbb-rrrr-062b46380bbf",
                 "revision": 1,
                 "created_at": "2014-04-17",
@@ -471,7 +471,7 @@ class TestMockPymesync(unittest.TestCase):
             },
             {
                 "name": "Planning",
-                "slugs": ["plan", "prep"],
+                "slug": "plan",
                 "uuid": "adf036f5-3d49-cccc-ssss-062b46380bbf",
                 "revision": 1,
                 "created_at": "2014-04-17",

--- a/pymesync/tests.py
+++ b/pymesync/tests.py
@@ -209,26 +209,6 @@ class TestPymesync(unittest.TestCase):
                               {self.ts.error:
                                "time object: must be python dictionary"})
 
-    def test_create_or_update_create_time_catch_request_error(self):
-        """Tests TimeSync._TimeSync__create_or_update for create time with
-        request error"""
-        time = {
-            "duration": 12,
-            "project": "ganet_web_manager",
-            "user": "example-user",
-            "activities": ["documenting"],
-            "notes": "Worked on docs",
-            "issue_uri": "https://github.com/",
-            "date_worked": "2014-04-17",
-        }
-
-        # To test that the exception is being caught with a bad baseurl,
-        # we need to use the actual post method
-        requests.post = actual_post
-
-        self.assertRaises(Exception, self.ts._TimeSync__create_or_update(
-            time, None, "time", "times"))
-
     def test_create_or_update_create_user_valid(self):
         """Tests TimeSync._TimeSync__create_or_update for create user with
         valid data"""
@@ -381,24 +361,6 @@ class TestPymesync(unittest.TestCase):
                                                                   "users"),
                               {self.ts.error:
                                "user object: must be python dictionary"})
-
-    def test_create_or_update_create_user_catch_request_error(self):
-        """Tests TimeSync._TimeSync__create_or_update for create user with
-        request error"""
-        user = {
-            "username": "example-user",
-            "password": "password",
-            "display_name": "Example User",
-            "email": "example.user@example.com",
-        }
-
-        # To test that the exception is being caught with a bad baseurl,
-        # we need to use the actual post method
-        requests.post = actual_post
-
-        self.assertRaises(Exception,
-                          self.ts._TimeSync__create_or_update(
-                              user, None, "user", "users"))
 
     def test_create_or_update_create_project_valid(self):
         """Tests TimeSync._TimeSync__create_or_update for create project with

--- a/pymesync/tests.py
+++ b/pymesync/tests.py
@@ -45,8 +45,7 @@ class TestPymesync(unittest.TestCase):
         ts = pymesync.TimeSync("baseurl")
         self.assertIsNone(ts.token)
 
-    @patch("pymesync.TimeSync._TimeSync__response_to_python")
-    def test_create_or_update_create_time_valid(self, m_resp_python):
+    def test_create_or_update_create_time_valid(self):
         """Tests TimeSync._TimeSync__create_or_update for create time with
         valid data"""
         # Parameters to be sent to TimeSync
@@ -76,8 +75,7 @@ class TestPymesync(unittest.TestCase):
         requests.post.assert_called_with("http://ts.example.com/v1/times",
                                          json=content)
 
-    @patch("pymesync.TimeSync._TimeSync__response_to_python")
-    def test_create_or_update_update_time_valid(self, m_resp_python):
+    def test_create_or_update_update_time_valid(self):
         """Tests TimeSync._TimeSync__create_or_update for update time with
         valid data"""
         # Parameters to be sent to TimeSync
@@ -111,9 +109,7 @@ class TestPymesync(unittest.TestCase):
             "http://ts.example.com/v1/times/{}".format(uuid),
             json=content)
 
-    @patch("pymesync.TimeSync._TimeSync__response_to_python")
-    def test_create_or_update_update_time_valid_less_fields(self,
-                                                            m_resp_python):
+    def test_create_or_update_update_time_valid_less_fields(self):
         """Tests TimeSync._TimeSync__create_or_update for update time with one
         valid parameter"""
         # Parameters to be sent to TimeSync
@@ -213,8 +209,7 @@ class TestPymesync(unittest.TestCase):
                               {self.ts.error:
                                "time object: must be python dictionary"})
 
-    @patch("pymesync.TimeSync._TimeSync__response_to_python")
-    def test_create_or_update_create_time_catch_request_error(self, m):
+    def test_create_or_update_create_time_catch_request_error(self):
         """Tests TimeSync._TimeSync__create_or_update for create time with
         request error"""
         time = {
@@ -234,8 +229,7 @@ class TestPymesync(unittest.TestCase):
         self.assertRaises(Exception, self.ts._TimeSync__create_or_update(
             time, None, "time", "times"))
 
-    @patch("pymesync.TimeSync._TimeSync__response_to_python")
-    def test_create_or_update_create_user_valid(self, m_resp_python):
+    def test_create_or_update_create_user_valid(self):
         """Tests TimeSync._TimeSync__create_or_update for create user with
         valid data"""
         # Parameters to be sent to TimeSync
@@ -262,8 +256,7 @@ class TestPymesync(unittest.TestCase):
         requests.post.assert_called_with("http://ts.example.com/v1/users",
                                          json=content)
 
-    @patch("pymesync.TimeSync._TimeSync__response_to_python")
-    def test_create_or_update_update_user_valid(self, m_resp_python):
+    def test_create_or_update_update_user_valid(self):
         """Tests TimeSync._TimeSync__create_or_update for update user with
         valid data"""
         # Parameters to be sent to TimeSync
@@ -295,9 +288,7 @@ class TestPymesync(unittest.TestCase):
             "http://ts.example.com/v1/users/{}".format(username),
             json=content)
 
-    @patch("pymesync.TimeSync._TimeSync__response_to_python")
-    def test_create_or_update_update_user_valid_less_fields(self,
-                                                            m_resp_python):
+    def test_create_or_update_update_user_valid_less_fields(self):
         """Tests TimeSync._TimeSync__create_or_update for update user with one
         valid parameter"""
         # Parameters to be sent to TimeSync
@@ -391,8 +382,7 @@ class TestPymesync(unittest.TestCase):
                               {self.ts.error:
                                "user object: must be python dictionary"})
 
-    @patch("pymesync.TimeSync._TimeSync__response_to_python")
-    def test_create_or_update_create_user_catch_request_error(self, m):
+    def test_create_or_update_create_user_catch_request_error(self):
         """Tests TimeSync._TimeSync__create_or_update for create user with
         request error"""
         user = {
@@ -410,8 +400,7 @@ class TestPymesync(unittest.TestCase):
                           self.ts._TimeSync__create_or_update(
                               user, None, "user", "users"))
 
-    @patch("pymesync.TimeSync._TimeSync__response_to_python")
-    def test_create_or_update_create_project_valid(self, m_resp_python):
+    def test_create_or_update_create_project_valid(self):
         """Tests TimeSync._TimeSync__create_or_update for create project with
         valid data"""
         # Parameters to be sent to TimeSync
@@ -442,8 +431,7 @@ class TestPymesync(unittest.TestCase):
         requests.post.assert_called_with("http://ts.example.com/v1/projects",
                                          json=content)
 
-    @patch("pymesync.TimeSync._TimeSync__response_to_python")
-    def test_create_or_update_update_project_valid(self, m_resp_python):
+    def test_create_or_update_update_project_valid(self):
         """Tests TimeSync._TimeSync__create_or_update for update project with
         valid parameters"""
         # Parameters to be sent to TimeSync
@@ -475,9 +463,7 @@ class TestPymesync(unittest.TestCase):
             "http://ts.example.com/v1/projects/slug",
             json=content)
 
-    @patch("pymesync.TimeSync._TimeSync__response_to_python")
-    def test_create_or_update_update_project_valid_less_fields(self,
-                                                               m_resp_python):
+    def test_create_or_update_update_project_valid_less_fields(self):
         """Tests TimeSync._TimeSync__create_or_update for update project with
         one valid parameter"""
         # Parameters to be sent to TimeSync
@@ -573,8 +559,7 @@ class TestPymesync(unittest.TestCase):
                               {self.ts.error:
                                "project object: must be python dictionary"})
 
-    @patch("pymesync.TimeSync._TimeSync__response_to_python")
-    def test_create_or_update_create_activity_valid(self, m_resp_python):
+    def test_create_or_update_create_activity_valid(self):
         """Tests TimeSync._TimeSync__create_or_update for create activity with
         valid data"""
         # Parameters to be sent to TimeSync
@@ -600,8 +585,7 @@ class TestPymesync(unittest.TestCase):
         requests.post.assert_called_with("http://ts.example.com/v1/activities",
                                          json=content)
 
-    @patch("pymesync.TimeSync._TimeSync__response_to_python")
-    def test_create_or_update_update_activity_valid(self, m_resp_python):
+    def test_create_or_update_update_activity_valid(self):
         """Tests TimeSync._TimeSync__create_or_update for update activity with
         valid parameters"""
         # Parameters to be sent to TimeSync
@@ -628,9 +612,7 @@ class TestPymesync(unittest.TestCase):
             "http://ts.example.com/v1/activities/slug",
             json=content)
 
-    @patch("pymesync.TimeSync._TimeSync__response_to_python")
-    def test_create_or_update_update_activity_valid_less_fields(self,
-                                                                m_resp_python):
+    def test_create_or_update_update_activity_valid_less_fields(self):
         """Tests TimeSync._TimeSync__create_or_update for update activity with
         one valid parameter"""
         # Parameters to be sent to TimeSync
@@ -1600,8 +1582,8 @@ class TestPymesync(unittest.TestCase):
                           python_object)
 
     def test_response_to_python_empty_response(self):
-        """Check that __response_to_python returns correctly for delete_*
-G       methods"""
+        """Check that __response_to_python returns correctly for delete_*G
+        methods"""
         response = resp()
         response.text = ""
         response.status_code = 200
@@ -1933,8 +1915,7 @@ G       methods"""
         self.assertEquals(bcrypt.hashpw("password", user["password"]),
                           user["password"])
 
-    @patch("pymesync.TimeSync._TimeSync__response_to_python")
-    def test_authentication(self, mock_response_to_python):
+    def test_authentication(self):
         """Tests authenticate method for url and data construction"""
         auth = {
             "auth": {
@@ -2075,8 +2056,7 @@ G       methods"""
                            "http://ts.example.com/v1 - "
                            "response status was 502"})
 
-    @patch("pymesync.TimeSync._TimeSync__response_to_python")
-    def test_delete_object_time(self, m_resp_python):
+    def test_delete_object_time(self):
         """Test that _delete_object calls requests.delete with the correct
         url"""
         requests.delete = mock.create_autospec(requests.delete)
@@ -2085,8 +2065,7 @@ G       methods"""
         self.ts._TimeSync__delete_object("times", "abcd-3453-3de3-99sh")
         requests.delete.assert_called_with(url)
 
-    @patch("pymesync.TimeSync._TimeSync__response_to_python")
-    def test_delete_object_project(self, m_resp_python):
+    def test_delete_object_project(self):
         """Test that _delete_object calls requests.delete with the correct
         url"""
         requests.delete = mock.create_autospec(requests.delete)
@@ -2095,8 +2074,7 @@ G       methods"""
         self.ts._TimeSync__delete_object("projects", "ts")
         requests.delete.assert_called_with(url)
 
-    @patch("pymesync.TimeSync._TimeSync__response_to_python")
-    def test_delete_object_activity(self, m_resp_python):
+    def test_delete_object_activity(self):
         """Test that _delete_object calls requests.delete with the correct
         url"""
         requests.delete = mock.create_autospec(requests.delete)
@@ -2105,8 +2083,7 @@ G       methods"""
         self.ts._TimeSync__delete_object("activities", "code")
         requests.delete.assert_called_with(url)
 
-    @patch("pymesync.TimeSync._TimeSync__response_to_python")
-    def test_delete_object_user(self, m_resp_python):
+    def test_delete_object_user(self):
         """Test that _delete_object calls requests.delete with the correct
         url"""
         requests.delete = mock.create_autospec(requests.delete)

--- a/pymesync/tests.py
+++ b/pymesync/tests.py
@@ -40,7 +40,7 @@ class TestPymesync(unittest.TestCase):
         self.assertEquals(ts.token, "TOKENTOCHECK")
 
     def test_instantiate_without_token(self):
-        """Test that instantiating pymesync without a token does not se the
+        """Test that instantiating pymesync without a token does not set the
         token variable"""
         ts = pymesync.TimeSync("baseurl")
         self.assertIsNone(ts.token)

--- a/pymesync/tests.py
+++ b/pymesync/tests.py
@@ -1861,6 +1861,28 @@ class TestPymesync(unittest.TestCase):
                                               "True or False".format(perm)})
 
     @patch("pymesync.TimeSync._TimeSync__create_or_update")
+    def test_create_user_unicode_password(self, mock_create_or_update):
+        """Tests that unicode password objects get encoded to UTF-8 before
+        being hashed"""
+        user = {
+            "username": "example-user",
+            "password": u"password",
+            "display_name": "Example User",
+            "email": "example.user@example.com",
+            "site_admin": True,
+            "site_spectator": False,
+            "site_manager": True,
+            "active": True,
+        }
+
+        encoded_password = user["password"].encode("utf-8")
+
+        self.ts.create_user(user)
+
+        self.assertEquals(bcrypt.hashpw(encoded_password, user["password"]),
+                          user["password"])
+
+    @patch("pymesync.TimeSync._TimeSync__create_or_update")
     def test_update_user(self, mock_create_or_update):
         """Tests that TimeSync.update_user calls _create_or_update with correct
         parameters"""
@@ -1875,6 +1897,28 @@ class TestPymesync(unittest.TestCase):
         mock_create_or_update.assert_called_with(user, "example", "user",
                                                  "users", False)
         self.assertEquals(bcrypt.hashpw("password", user["password"]),
+                          user["password"])
+
+    @patch("pymesync.TimeSync._TimeSync__create_or_update")
+    def test_update_user_unicode_password(self, mock_create_or_update):
+        """Tests that unicode password objects get encoded to UTF-8 before
+        being hashed"""
+        user = {
+            "username": "example-user",
+            "password": u"password",
+            "display_name": "Example User",
+            "email": "example.user@example.com",
+            "site_admin": True,
+            "site_spectator": False,
+            "site_manager": True,
+            "active": True,
+        }
+
+        encoded_password = user["password"].encode("utf-8")
+
+        self.ts.update_user(user, user["username"])
+
+        self.assertEquals(bcrypt.hashpw(encoded_password, user["password"]),
                           user["password"])
 
     def test_authentication(self):

--- a/pymesync/tests.py
+++ b/pymesync/tests.py
@@ -1861,28 +1861,6 @@ class TestPymesync(unittest.TestCase):
                                               "True or False".format(perm)})
 
     @patch("pymesync.TimeSync._TimeSync__create_or_update")
-    def test_create_user_unicode_password(self, mock_create_or_update):
-        """Tests that unicode password objects get encoded to UTF-8 before
-        being hashed"""
-        user = {
-            "username": "example-user",
-            "password": u"password",
-            "display_name": "Example User",
-            "email": "example.user@example.com",
-            "site_admin": True,
-            "site_spectator": False,
-            "site_manager": True,
-            "active": True,
-        }
-
-        encoded_password = user["password"].encode("utf-8")
-
-        self.ts.create_user(user)
-
-        self.assertEquals(bcrypt.hashpw(encoded_password, user["password"]),
-                          user["password"])
-
-    @patch("pymesync.TimeSync._TimeSync__create_or_update")
     def test_update_user(self, mock_create_or_update):
         """Tests that TimeSync.update_user calls _create_or_update with correct
         parameters"""
@@ -2248,6 +2226,51 @@ class TestPymesync(unittest.TestCase):
                           (time['duration']),
                           [{self.ts.error:
                             "time object: invalid duration string"}])
+
+    def test_hash_user_password_unicode(self):
+        """Tests that unicode passwords are hashed correctly"""
+        user = {
+            u"username": u"user",
+            u"password": u"pass"
+        }
+
+        encoded_password = user["password"].encode("utf-8")
+
+        self.ts._TimeSync__hash_user_password(user)
+
+        self.assertEquals(bcrypt.hashpw(encoded_password, user["password"]),
+                          user["password"])
+
+    def test_hash_user_password_nonunicode(self):
+        """Tests that non-unicode passwords are hashed correctly"""
+        user = {
+            "username": "user",
+            "password": "pass"
+        }
+
+        password = user["password"]
+
+        self.ts._TimeSync__hash_user_password(user)
+
+        self.assertEquals(bcrypt.hashpw(password, user["password"]),
+                          user["password"])
+
+    def test_duration_invalid(self):
+        """Tests for duration validity - if the duration given is a negative
+        int, an error message is returned"""
+        time = {
+            "duration": -12600,
+            "project": "ganeti-web-manager",
+            "user": "example-user",
+            "activities": ["documenting"],
+            "notes": "Worked on docs",
+            "issue_uri": "https://github.com/",
+            "date_worked": "2014-04-17",
+        }
+
+        self.assertEquals(self.ts.create_time(time),
+                          {self.ts.error:
+                           "time object: duration cannot be negative"})
 
     def test_project_users_valid(self):
         """Test project_users method with a valid project object returned from

--- a/pymesync/tests.py
+++ b/pymesync/tests.py
@@ -1861,6 +1861,28 @@ class TestPymesync(unittest.TestCase):
                                               "True or False".format(perm)})
 
     @patch("pymesync.TimeSync._TimeSync__create_or_update")
+    def test_create_user_unicode_password(self, mock_create_or_update):
+        """Tests that unicode password objects get encoded to UTF-8 before
+        being hashed"""
+        user = {
+            "username": "example-user",
+            "password": u"password",
+            "display_name": "Example User",
+            "email": "example.user@example.com",
+            "site_admin": True,
+            "site_spectator": False,
+            "site_manager": True,
+            "active": True,
+        }
+
+        encoded_password = user["password"].encode("utf-8")
+
+        self.ts.create_user(user)
+
+        self.assertEquals(bcrypt.hashpw(encoded_password, user["password"]),
+                          user["password"])
+
+    @patch("pymesync.TimeSync._TimeSync__create_or_update")
     def test_update_user(self, mock_create_or_update):
         """Tests that TimeSync.update_user calls _create_or_update with correct
         parameters"""

--- a/pymesync/tests.py
+++ b/pymesync/tests.py
@@ -2266,23 +2266,6 @@ G       methods"""
                           [{self.ts.error:
                             "time object: invalid duration string"}])
 
-    def test_duration_invalid(self):
-        """Tests for duration validity - if the duration given is a negative
-        int, an error message is returned"""
-        time = {
-            "duration": -12600,
-            "project": "ganeti-web-manager",
-            "user": "example-user",
-            "activities": ["documenting"],
-            "notes": "Worked on docs",
-            "issue_uri": "https://github.com/",
-            "date_worked": "2014-04-17",
-        }
-
-        self.assertEquals(self.ts.create_time(time),
-                          {self.ts.error:
-                           "time object: duration cannot be negative"})
-
     def test_project_users_valid(self):
         """Test project_users method with a valid project object returned from
         TimeSync"""


### PR DESCRIPTION
<!--
  This is a guideline for what a PR should look like.
  Feel free to modify it to fit your specific needs.

  Please list the issue this fixes in the PR
-->
fixes issue #149 

## Changes in this PR.
<!--
  Please include a list of all things this PR will accomplish
  Use the checkbox syntax to show what is done and what is yet to be completed.
  This gives context to the diff.
-->

- [X] If "password" is a Unicode object inside create/update user, encode it as UTF-8 so bcrypt doesn't raise a TypeError

## Testing this PR.
<!--
  Please include a list of explicit instructions for testing this PR.
  If the instructions are 'run `make test`' say that,
  If they are more complicated be thorough.
-->

1. Run `make test`
2. Attempt to create/update a user with a Unicode password while authenticated as a site admin

@osuosl/devs

