### PR TITLE
Fixed update_project and get_project in mock pymesync

### DIFF
--- a/pymesync/mock_pymesync.py
+++ b/pymesync/mock_pymesync.py
@@ -68,17 +68,17 @@ def update_project(p_dict, slug):
         "deleted_at": None,
         "uuid": "309eae69-21dc-4538-9fdc-e6892a9c4dd4",
         "revision": 2,
-        "users": {
-            "members": [
-                "patcht",
-                "tschuy"
-            ],
-            "spectators": [
-                "tschuy"
-            ],
-            "managers": [
-                "tschuy"
-            ]
+        "users": p_dict["users"] if "users" in p_dict else {
+            "patcht": {
+                "member": True,
+                "spectator": False,
+                "manager": False
+            },
+            "tschuy": {
+                "member": True,
+                "spectator": True,
+                "manager": True
+            }
         }
     }
     return updated_param
@@ -212,16 +212,16 @@ def get_projects(slug):
             "deleted_at": None,
             "updated_at": "2014-07-20",
             "users": {
-                "members": [
-                    "patcht",
-                    "tschuy"
-                ],
-                "spectators": [
-                    "tschuy"
-                ],
-                "managers": [
-                    "tschuy"
-                ]
+                "patcht": {
+                    "member": True,
+                    "spectator": False,
+                    "manager": False
+                },
+                "tschuy": {
+                    "member": True,
+                    "spectator": True,
+                    "manager": True
+                }
             }
         }
     ]
@@ -237,18 +237,21 @@ def get_projects(slug):
                 "deleted_at": None,
                 "updated_at": "2014-07-20",
                 "users": {
-                    "members": [
-                        "patcht",
-                        "tschuy",
-                        "mrsj"
-                    ],
-                    "spectators": [
-                        "tschuy",
-                        "mrsj"
-                    ],
-                    "managers": [
-                        "tschuy"
-                    ]
+                    "patcht": {
+                        "member": True,
+                        "spectator": False,
+                        "manager": False
+                    },
+                    "mrsj": {
+                        "member": True,
+                        "spectator": True,
+                        "manager": False
+                    },
+                    "tschuy": {
+                        "member": True,
+                        "spectator": True,
+                        "manager": True
+                    }
                 }
             }
         )
@@ -264,20 +267,31 @@ def get_projects(slug):
                 "deleted_at": None,
                 "updated_at": "2014-07-20",
                 "users": {
-                    "members": [
-                        "patcht",
-                        "tschuy",
-                        "mrsj",
-                        "MaraJade",
-                        "thai"
-                    ],
-                    "spectators": [
-                        "tschuy",
-                        "mrsj"
-                    ],
-                    "managers": [
-                        "mrsj"
-                    ]
+                    "patcht": {
+                        "member": True,
+                        "spectator": False,
+                        "manager": False
+                    },
+                    "tschuy": {
+                        "member": True,
+                        "spectator": True,
+                        "manager": False
+                    },
+                    "mrsj": {
+                        "member": True,
+                        "spectator": True,
+                        "manager": True
+                    },
+                    "MaraJade": {
+                        "member": True,
+                        "spectator": False,
+                        "manager": False
+                    },
+                    "thai": {
+                        "member": True,
+                        "spectator": False,
+                        "manager": False
+                    }
                 }
             }
         )

--- a/pymesync/test_mock_pymesync.py
+++ b/pymesync/test_mock_pymesync.py
@@ -168,16 +168,16 @@ class TestMockPymesync(unittest.TestCase):
             "uuid": "309eae69-21dc-4538-9fdc-e6892a9c4dd4",
             "revision": 2,
             "users": {
-                "members": [
-                    "patcht",
-                    "tschuy"
-                ],
-                "spectators": [
-                    "tschuy"
-                ],
-                "managers": [
-                    "tschuy"
-                ]
+                "patcht": {
+                    "member": True,
+                    "spectator": False,
+                    "manager": False
+                },
+                "tschuy": {
+                    "member": True,
+                    "spectator": True,
+                    "manager": True
+                }
             }
         }
 
@@ -341,16 +341,16 @@ class TestMockPymesync(unittest.TestCase):
             "deleted_at": None,
             "updated_at": "2014-07-20",
             "users": {
-                "members": [
-                    "patcht",
-                    "tschuy"
-                ],
-                "spectators": [
-                    "tschuy"
-                ],
-                "managers": [
-                    "tschuy"
-                ]
+                "patcht": {
+                    "member": True,
+                    "spectator": False,
+                    "manager": False
+                },
+                "tschuy": {
+                    "member": True,
+                    "spectator": True,
+                    "manager": True
+                }
             }
         }]
 
@@ -369,16 +369,16 @@ class TestMockPymesync(unittest.TestCase):
                 "deleted_at": None,
                 "updated_at": "2014-07-20",
                 "users": {
-                    "members": [
-                        "patcht",
-                        "tschuy"
-                    ],
-                    "spectators": [
-                        "tschuy"
-                    ],
-                    "managers": [
-                        "tschuy"
-                    ]
+                    "patcht": {
+                        "member": True,
+                        "spectator": False,
+                        "manager": False
+                    },
+                    "tschuy": {
+                        "member": True,
+                        "spectator": True,
+                        "manager": True
+                    }
                 }
             },
             {
@@ -391,18 +391,21 @@ class TestMockPymesync(unittest.TestCase):
                 "deleted_at": None,
                 "updated_at": "2014-07-20",
                 "users": {
-                    "members": [
-                        "patcht",
-                        "tschuy",
-                        "mrsj"
-                    ],
-                    "spectators": [
-                        "tschuy",
-                        "mrsj"
-                    ],
-                    "managers": [
-                        "tschuy"
-                    ]
+                    "patcht": {
+                        "member": True,
+                        "spectator": False,
+                        "manager": False
+                    },
+                    "mrsj": {
+                        "member": True,
+                        "spectator": True,
+                        "manager": False
+                    },
+                    "tschuy": {
+                        "member": True,
+                        "spectator": True,
+                        "manager": True
+                    }
                 }
             },
             {
@@ -415,20 +418,31 @@ class TestMockPymesync(unittest.TestCase):
                 "deleted_at": None,
                 "updated_at": "2014-07-20",
                 "users": {
-                    "members": [
-                        "patcht",
-                        "tschuy",
-                        "mrsj",
-                        "MaraJade",
-                        "thai"
-                    ],
-                    "spectators": [
-                        "tschuy",
-                        "mrsj"
-                    ],
-                    "managers": [
-                        "mrsj"
-                    ]
+                    "patcht": {
+                        "member": True,
+                        "spectator": False,
+                        "manager": False
+                    },
+                    "tschuy": {
+                        "member": True,
+                        "spectator": True,
+                        "manager": False
+                    },
+                    "mrsj": {
+                        "member": True,
+                        "spectator": True,
+                        "manager": True
+                    },
+                    "MaraJade": {
+                        "member": True,
+                        "spectator": False,
+                        "manager": False
+                    },
+                    "thai": {
+                        "member": True,
+                        "spectator": False,
+                        "manager": False
+                    }
                 }
             }
         ]


### PR DESCRIPTION
<!--
  This is a guideline for what a PR should look like.
  Feel free to modify it to fit your specific needs.

  Please list the issue this fixes in the PR
-->
fixes issue #161 

## Changes in this PR.
<!--
  Please include a list of all things this PR will accomplish
  Use the checkbox syntax to show what is done and what is yet to be completed.
  This gives context to the diff.
-->

- [X] The mock functions for `update_project` and `get_project` now return properly formatted user permissions
- [X] Tests for mock pymesync have been updated to reflect this fix

## Testing this PR.
<!--
  Please include a list of explicit instructions for testing this PR.
  If the instructions are 'run `make test`' say that,
  If they are more complicated be thorough.
-->

1. Run `make test` inside the `pymesync/` directory

@osuosl/devs

