### PR TITLE
Added "user" query parameter to get_projects

### DIFF
--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -466,6 +466,10 @@ TimeSync.\ **get_projects(query_parameters=None)**
 
       - example: ``{"slug": "gwm"}``
 
+    * ``user`` - filter project request by one or more users
+
+      - example: ``{"user": ["userone", "usertwo"]}``
+
     * ``include_deleted`` - tell TimeSync whether to include deleted projects in
       request. Default is ``False`` and cannot be combined with a ``slug``.
 

--- a/pymesync/pymesync.py
+++ b/pymesync/pymesync.py
@@ -753,6 +753,14 @@ class TimeSync(object):
             query_string = "/{}?".format(queries["slug"])
             del(queries["slug"])
 
+        # Check for the "user" field for a get_projects query
+        if "user" in queries:
+            for user in queries["user"]:
+                query_list.append("{0}={1}".format("user", user))
+
+            # Delete "user" so the code below doesn't try to use it
+            del(queries["user"])
+
         # Convert True and False booleans to TimeSync compatible strings
         for k, v in sorted(queries.items(), key=operator.itemgetter(0)):
             queries[k] = "true" if v else "false"

--- a/pymesync/tests.py
+++ b/pymesync/tests.py
@@ -1247,6 +1247,39 @@ class TestPymesync(unittest.TestCase):
                           [{"this": "should be in a list"}])
         requests.get.assert_called_with(url)
 
+    def test_get_projects_user(self):
+        """Tests TimeSync.get_projects with user query"""
+        response = resp()
+        response.text = json.dumps({"this": "should be in a list"})
+
+        # Mock requests.get
+        requests.get = mock.create_autospec(requests.get,
+                                            return_value=response)
+
+        url = "{0}/projects?user=userone&token={1}".format(self.ts.baseurl,
+                                                           self.ts.token)
+
+        self.assertEquals(self.ts.get_projects({"user": ["userone"]}),
+                          [{"this": "should be in a list"}])
+        requests.get.assert_called_with(url)
+
+    def test_get_projects_user_include_deleted(self):
+        """Tests TimeSync.get_projects with user and include_deleted queries"""
+        response = resp()
+        response.text = json.dumps({"this": "should be in a list"})
+
+        # Mock requests.get
+        requests.get = mock.create_autospec(requests.get,
+                                            return_value=response)
+
+        url = "{0}/projects?user=userone&include_deleted=true&token={1}" \
+            .format(self.ts.baseurl, self.ts.token)
+
+        self.assertEquals(self.ts.get_projects({"user": ["userone"],
+                                                "include_deleted": True}),
+                          [{"this": "should be in a list"}])
+        requests.get.assert_called_with(url)
+
     def test_get_activities(self):
         """Tests TimeSync.get_activities"""
         response = resp()


### PR DESCRIPTION
<!--
  This is a guideline for what a PR should look like.
  Feel free to modify it to fit your specific needs.

  Please list the issue this fixes in the PR
-->
fixes issue #163 

## Changes in this PR.
<!--
  Please include a list of all things this PR will accomplish
  Use the checkbox syntax to show what is done and what is yet to be completed.
  This gives context to the diff.
-->

- [X] Added support for the "user" query parameter on the `/projects` TimeSync endpoint
- [X] Added documentation for the new parameter

## Testing this PR.
<!--
  Please include a list of explicit instructions for testing this PR.
  If the instructions are 'run `make test`' say that,
  If they are more complicated be thorough.
-->

1. Run `make verify`
2. Run this script with `python`:

```
import pymesync
ts = pymesync.TimeSync(baseurl='http://timesync-staging.osuosl.org/v0')
ts.authenticate('admin', 'timesync-staging', 'password')
ts.get_projects({"user": ["mrsj"]})
```

See that all of the projects that were returned contain the user "mrsj"

@osuosl/devs
