### PR TITLE
Fixed start and end query parameters

### DIFF
--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -363,9 +363,10 @@ TimeSync.\ **get_times(query_parameters=None)**
     ``query_parameters`` is missing, it defaults to ``None``, in which case
     ``get_times()`` will return all times the current user is authorized to see.
     The syntax for each argument is ``{"query": ["parameter1", "parameter2"]}``
-    except for the ``uuid`` parameter which is ``{"uuid": "uuid-as-string"}``
-    and the ``include_deleted`` and ``include_revisions`` parameters which
-    should be set to booleans.
+    except for the ``start`` and ``end`` parameters which are ISO 8601 date
+    strings, the ``uuid`` parameter which is ``{"uuid": "uuid-as-string"}``, and
+    the ``include_deleted`` and ``include_revisions`` parameters which should be
+    set to booleans.
 
     Currently the valid queries allowed by pymesync are:
 
@@ -383,11 +384,11 @@ TimeSync.\ **get_times(query_parameters=None)**
 
     * ``start`` - filter time request by start date
 
-      - example: ``{"start": ["2014-07-23"]}``
+      - example: ``{"start": "2014-07-23"}``
 
     * ``end`` - filter time request by end date
 
-      - example: ``{"end": ["2015-07-23"]}``
+      - example: ``{"end": "2015-07-23"}``
 
     * ``include_revisions`` - either ``True`` or ``False`` to include
       revisions of times. Defaults to ``False``

--- a/pymesync/pymesync.py
+++ b/pymesync/pymesync.py
@@ -799,6 +799,13 @@ class TimeSync(object):
 
         # Everthing is a list now, so iterate through and append
         else:
+            # Put "start" and "end" queries into lists for below code
+            if "start" in queries and isinstance(queries["start"], str):
+                queries["start"] = [queries["start"]]
+
+            if "end" in queries and isinstance(queries["end"], str):
+                queries["end"] = [queries["end"]]
+
             # Sort them into an alphabetized list for easier testing
             sorted_qs = sorted(queries.items(), key=operator.itemgetter(0))
             for query, param in sorted_qs:

--- a/pymesync/tests.py
+++ b/pymesync/tests.py
@@ -874,6 +874,23 @@ class TestPymesync(unittest.TestCase):
                          [{"this": "should be in a list"}])
         requests.get.assert_called_with(url)
 
+    def test_get_time_for_start_date_string(self):
+        """Tests TimeSync.get_times with start date query parameter"""
+        response = resp()
+        response.text = json.dumps({"this": "should be in a list"})
+
+        # Mock requests.get
+        requests.get = mock.create_autospec(requests.get,
+                                            return_value=response)
+
+        url = "{0}/times?start=2015-07-23&token={1}".format(self.ts.baseurl,
+                                                            self.ts.token)
+
+        # Test that requests.get was called with baseurl and correct parameter
+        self.assertEqual(self.ts.get_times({"start": "2015-07-23"}),
+                         [{"this": "should be in a list"}])
+        requests.get.assert_called_with(url)
+
     def test_get_time_for_end_date(self):
         """Tests TimeSync.get_times with end date query parameter"""
         response = resp()
@@ -888,6 +905,23 @@ class TestPymesync(unittest.TestCase):
 
         # Test that requests.get was called with baseurl and correct parameter
         self.assertEqual(self.ts.get_times({"end": ["2015-07-23"]}),
+                         [{"this": "should be in a list"}])
+        requests.get.assert_called_with(url)
+
+    def test_get_time_for_end_date_string(self):
+        """Tests TimeSync.get_times with end date query parameter"""
+        response = resp()
+        response.text = json.dumps({"this": "should be in a list"})
+
+        # Mock requests.get
+        requests.get = mock.create_autospec(requests.get,
+                                            return_value=response)
+
+        url = "{0}/times?end=2015-07-23&token={1}".format(self.ts.baseurl,
+                                                          self.ts.token)
+
+        # Test that requests.get was called with baseurl and correct parameter
+        self.assertEqual(self.ts.get_times({"end": "2015-07-23"}),
                          [{"this": "should be in a list"}])
         requests.get.assert_called_with(url)
 


### PR DESCRIPTION
<!--
  This is a guideline for what a PR should look like.
  Feel free to modify it to fit your specific needs.

  Please list the issue this fixes in the PR
-->
fixes issue #167 

## Changes in this PR.
<!--
  Please include a list of all things this PR will accomplish
  Use the checkbox syntax to show what is done and what is yet to be completed.
  This gives context to the diff.
-->

- [X] Allow "start" and "end" query parameters in `get_times` to be sent as strings instead of lists
- [X] Updated tests and docs to reflect the change

## Testing this PR.
<!--
  Please include a list of explicit instructions for testing this PR.
  If the instructions are 'run `make test`' say that,
  If they are more complicated be thorough.
-->

1. Run `make verify`
2. Run this script or type these into the python shell

```
import pymesync
ts = pymesync.TimeSync(baseurl="http://timesync-staging.osuosl.org/v0")
ts.authenticate("test", "test", "password")
print ts.get_times(query_parameters={"start": "2016-01-01", "end": "2016-06-01"})
```

@osuosl/devs

