### PR TITLE
Fixed KeyError in project_users()

### DIFF
--- a/pymesync/pymesync.py
+++ b/pymesync/pymesync.py
@@ -684,7 +684,7 @@ class TimeSync(object):
             return project_object
 
         # Get the user object from the project
-        users = project_object["users"]
+        users = project_object.setdefault("users", {})
 
         # Convert the nested permissions dict to a list containing only
         # relevant (true) permissions


### PR DESCRIPTION
<!--
  This is a guideline for what a PR should look like.
  Feel free to modify it to fit your specific needs.

  Please list the issue this fixes in the PR
-->
fixes issue #169 

## Changes in this PR.
<!--
  Please include a list of all things this PR will accomplish
  Use the checkbox syntax to show what is done and what is yet to be completed.
  This gives context to the diff.
-->

- [X] If `project_users` is called and `project` is the slug for a project that has no users, Pymesync no longer raises a KeyError

## Testing this PR.
<!--
  Please include a list of explicit instructions for testing this PR.
  If the instructions are 'run `make test`' say that,
  If they are more complicated be thorough.
-->
1.Run this script
```python
import pymesync
ts = pymesync.TimeSync(baseurl="http://timesync-staging.osuosl.org/v0")
ts.authenticate("test", "test", "password")
ts.project_users(project="tp")
```
2.See that it doesn't raise a KeyError and that `ts.project_users(project="tp")` just returns an empty dict

@osuosl/devs

