### PR TITLE
Allow "start" and "end" query parameters to be submitted as strings

### DIFF
--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -366,9 +366,10 @@ TimeSync.\ **get_times(query_parameters=None)**
     ``query_parameters`` is missing, it defaults to ``None``, in which case
     ``get_times()`` will return all times the current user is authorized to see.
     The syntax for each argument is ``{"query": ["parameter1", "parameter2"]}``
-    except for the ``uuid`` parameter which is ``{"uuid": "uuid-as-string"}``
-    and the ``include_deleted`` and ``include_revisions`` parameters which
-    should be set to booleans.
+    except for the ``start`` and ``end`` parameters which are ISO 8601 date
+    strings, the ``uuid`` parameter which is ``{"uuid": "uuid-as-string"}``, and
+    the ``include_deleted`` and ``include_revisions`` parameters which should be
+    set to booleans.
 
     Currently the valid queries allowed by pymesync are:
 
@@ -386,11 +387,11 @@ TimeSync.\ **get_times(query_parameters=None)**
 
     * ``start`` - filter time request by start date
 
-      - example: ``{"start": ["2014-07-23"]}``
+      - example: ``{"start": "2014-07-23"}``
 
     * ``end`` - filter time request by end date
 
-      - example: ``{"end": ["2015-07-23"]}``
+      - example: ``{"end": "2015-07-23"}``
 
     * ``include_revisions`` - either ``True`` or ``False`` to include
       revisions of times. Defaults to ``False``

--- a/pymesync/pymesync.py
+++ b/pymesync/pymesync.py
@@ -817,11 +817,13 @@ class TimeSync(object):
 
         # Everthing is a list now, so iterate through and append
         else:
-            # Put "start" and "end" queries into lists
-            if "start" in queries and isinstance(queries["start"], str):
+            # If "start" or "end" parameters are strings, convert them to
+            # single-item lists internally so the query string construction
+            # below can process them
+            if "start" in queries and isinstance(queries["start"], basestring):
                 queries["start"] = [queries["start"]]
 
-            if "end" in queries and isinstance(queries["end"], str):
+            if "end" in queries and isinstance(queries["end"], basestring):
                 queries["end"] = [queries["end"]]
 
             # Sort them into an alphabetized list for easier testing

--- a/pymesync/pymesync.py
+++ b/pymesync/pymesync.py
@@ -817,6 +817,13 @@ class TimeSync(object):
 
         # Everthing is a list now, so iterate through and append
         else:
+            # Put "start" and "end" queries into lists
+            if "start" in queries and isinstance(queries["start"], str):
+                queries["start"] = [queries["start"]]
+
+            if "end" in queries and isinstance(queries["end"], str):
+                queries["end"] = [queries["end"]]
+
             # Sort them into an alphabetized list for easier testing
             sorted_qs = sorted(queries.items(), key=operator.itemgetter(0))
             for query, param in sorted_qs:

--- a/pymesync/pymesync.py
+++ b/pymesync/pymesync.py
@@ -33,8 +33,13 @@ import datetime
 import time
 import bcrypt
 import six
+import sys
 
 from . import mock_pymesync
+
+
+if sys.version_info[0] >= 3:
+    basestring = (str, bytes)
 
 
 class TimeSync(object):

--- a/tests/test_pymesync.py
+++ b/tests/test_pymesync.py
@@ -853,7 +853,7 @@ class TestPymesync(unittest.TestCase):
                                                             self.ts.token)
 
         # Test that requests.get was called with baseurl and correct parameter
-        self.assertEqual(self.ts.get_times({"start": ["2015-07-23"]}),
+        self.assertEqual(self.ts.get_times({"start": "2015-07-23"}),
                          [{"this": "should be in a list"}])
         requests.get.assert_called_with(url)
 
@@ -869,7 +869,7 @@ class TestPymesync(unittest.TestCase):
                                                           self.ts.token)
 
         # Test that requests.get was called with baseurl and correct parameter
-        self.assertEqual(self.ts.get_times({"end": ["2015-07-23"]}),
+        self.assertEqual(self.ts.get_times({"end": "2015-07-23"}),
                          [{"this": "should be in a list"}])
         requests.get.assert_called_with(url)
 


### PR DESCRIPTION
<!--
  This is a guideline for what a PR should look like.
  Feel free to modify it to fit your specific needs.

  Please list the issue this fixes in the PR
-->
fixes issue #167 

## Changes in this PR.
<!--
  Please include a list of all things this PR will accomplish
  Use the checkbox syntax to show what is done and what is yet to be completed.
  This gives context to the diff.
-->

- [X] Allow "start" and "end" query parameters in `get_times` to be sent as strings instead of lists
- [X] Updated tests and docs to reflect the change

## Testing this PR.
<!--
  Please include a list of explicit instructions for testing this PR.
  If the instructions are 'run `make test`' say that,
  If they are more complicated be thorough.
-->

1. Run `make verify`
2. Run this script or type these into the python shell

```
import pymesync
ts = pymesync.TimeSync(baseurl="http://timesync-staging.osuosl.org/v0")
ts.authenticate("test", "test", "password")
print ts.get_times(query_parameters={"start": "2016-01-01", "end": "2016-06-01"})
```

@osuosl/devs
