### PR TITLE
update bcrypt version to work with newer versions of python

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,11 @@ language: python
 
 python:
   - "2.7"
-  - "3.3"
   - "3.4"
   - "3.5"
+  - "3.6"
+  - "3.7"
+  - "3.8"
 
 notifications:
   email: false

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,4 @@ requests==2.8.1
 six==1.10.0
 wsgiref==0.1.2 ; python_version < '3.2'
 Sphinx==1.3.1
-bcrypt==2.0.0
+bcrypt==3.1.7

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ dependencies = [
     'pbr==1.8.1',
     'requests==2.8.1',
     'six==1.10.0',
-    'bcrypt==2.0.0',
+    'bcrypt==3.1.7',
 ]
 
 setup(


### PR DESCRIPTION
Fixes an issue in Debian 10 / python 2.7 where bcrypt wasn't able to find gnu-crypt.h